### PR TITLE
Fix BigNumber Typo in templates

### DIFF
--- a/src/pages/daos/[daoAddress]/proposal-templates/new/index.tsx
+++ b/src/pages/daos/[daoAddress]/proposal-templates/new/index.tsx
@@ -78,7 +78,7 @@ export default function CreateProposalTemplatePage() {
                 ...tx,
                 ethValue: {
                   value: tx.ethValue.value,
-                  bigNumerValue: BigNumber.from(tx.ethValue.value || 0),
+                  bigNumberValue: BigNumber.from(tx.ethValue.value || 0),
                 },
               })),
             };


### PR DESCRIPTION
While exploring the myosin DAO's template execution error is was discovered that the reason why the template would not execution was caused by an error in the template's creation. The json contains a typo in the `ethValue` property. newer templates doesn't have this typo. 

I did however notice that one more typo still exists though it doesn't seem to affect new templates.

Edit:
This was in fact effecting creation of forked templates.