### PR TITLE
Make displayed avatars consistent for same addresses

### DIFF
--- a/src/components/Activity/ActivityDescriptionGovernance.tsx
+++ b/src/components/Activity/ActivityDescriptionGovernance.tsx
@@ -1,6 +1,7 @@
 import { Box, Flex, Text } from '@chakra-ui/react';
 import { useTranslation } from 'react-i18next';
 import { useGetMetadata } from '../../hooks/DAO/proposal/useGetMetadata';
+import useAvatar from '../../hooks/utils/useAvatar';
 import useDisplayName from '../../hooks/utils/useDisplayName';
 import {
   Activity,
@@ -52,6 +53,8 @@ function ProposalAuthor({ activity }: { activity: Activity }) {
       : multisigProposal.confirmations[0].owner;
 
   const { displayName: author } = useDisplayName(proposer);
+  const avatarURL = useAvatar(author);
+
   return (
     <Flex
       gap={2}
@@ -61,7 +64,8 @@ function ProposalAuthor({ activity }: { activity: Activity }) {
     >
       <Avatar
         size="sm"
-        address={author}
+        address={proposer}
+        url={avatarURL}
       />
       <Box>{author}</Box>
     </Flex>

--- a/src/components/ui/menus/AccountDisplay/MenuButtonDisplay.tsx
+++ b/src/components/ui/menus/AccountDisplay/MenuButtonDisplay.tsx
@@ -25,7 +25,7 @@ export function Connected() {
   } = useFractal();
   const account = user.address;
   const { displayName: accountDisplayName } = useDisplayName(account);
-  const avatarURL = useAvatar(account);
+  const avatarURL = useAvatar(accountDisplayName);
 
   if (!account) {
     return null;


### PR DESCRIPTION
Closes #1499 

See attached issue (#1499) for screenshots demonstrating the problem.

## Screenshots demonstrating the fixes

### No ENS name set:
![Screenshot 2024-03-27 at 2 19 34 PM](https://github.com/decentdao/fractal-interface/assets/706929/11b2c062-871f-4621-9cc3-8eee5dae1db4)

### ENS name set, but no custom PFP:
![Screenshot 2024-03-27 at 2 18 10 PM](https://github.com/decentdao/fractal-interface/assets/706929/d0d80942-f7a9-416a-a215-f8688300523a)

### ENS name set, custom PFP:
![Screenshot 2024-03-27 at 2 16 42 PM](https://github.com/decentdao/fractal-interface/assets/706929/1b982b11-6483-43aa-bb79-76f4705cbc22)

