### PR TITLE
Add better typing to `useAsyncRetry`

### DIFF
--- a/src/components/pages/DaoHierarchy/useFetchNodes.tsx
+++ b/src/components/pages/DaoHierarchy/useFetchNodes.tsx
@@ -96,7 +96,7 @@ export function useFetchNodes(address?: string) {
     for await (const subDAO of nodes) {
       try {
         const safeInfo = await requestWithRetries(() => fetchDAOInfo(subDAO.address), 5, 5000);
-        if (safeInfo.guard) {
+        if (safeInfo && safeInfo.guard) {
           if (safeInfo.guard === ethers.constants.AddressZero) {
             subDAOs.push(safeInfo);
           } else {

--- a/src/hooks/DAO/loaders/governance/useAzoriusProposals.ts
+++ b/src/hooks/DAO/loaders/governance/useAzoriusProposals.ts
@@ -167,10 +167,12 @@ export const useAzoriusProposals = () => {
         );
       };
       const proposal = await requestWithRetries(func, 5, 7000);
-      action.dispatch({
-        type: FractalGovernanceAction.UPDATE_PROPOSALS_NEW,
-        payload: proposal,
-      });
+      if (proposal) {
+        action.dispatch({
+          type: FractalGovernanceAction.UPDATE_PROPOSALS_NEW,
+          payload: proposal,
+        });
+      }
     },
     [
       baseContracts,

--- a/src/hooks/utils/useAsyncRetry.ts
+++ b/src/hooks/utils/useAsyncRetry.ts
@@ -5,15 +5,9 @@ function sleep(ms: number) {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
-export type RequestWithRetries<FuncRes = any> = (
-  func: () => Promise<FuncRes>,
-  retries: number,
-  secondsToWait?: number,
-) => Promise<FuncRes | {} | null | undefined>;
-
 export function useAsyncRetry() {
-  const requestWithRetries: RequestWithRetries = useCallback(
-    async (func: () => Promise<any>, retries: number, secondsToWait: number = 2000) => {
+  const requestWithRetries = useCallback(
+    async <T>(func: () => Promise<T>, retries: number, secondsToWait: number = 2000) => {
       let currentRetries = 0;
       let result = null;
 


### PR DESCRIPTION
The `useAsyncRetry` hook returns a function called `requestWithRetries`.

`requestWithRetries` takes a function as an input parameter, and then returns back `Promise<any>`. 

What is happening in `requestWithRetries` is that it calls that input function many times until the function succeeds, and then returns back the result of that function. So, it's kind of generic.

However, I think it would be better if there was stronger typing on `requestWithRetries`. Instead of returning back `Promise<any>`, it should return `Promise<T>`, where `T` is the return type of its input function.

This PR does that, then cleans up a couple of new linter errors from that improvement.