### PR TITLE
Load proposals sequentially

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -66,7 +66,6 @@
         "@testing-library/react": "^14.2.1",
         "@types/react": "^18.0.17",
         "@types/react-dom": "^18.0.6",
-        "@types/remove-markdown": "^0.3.4",
         "@typescript-eslint/eslint-plugin": "^6.19.0",
         "@typescript-eslint/parser": "^6.19.0",
         "@vitejs/plugin-react": "^4.2.1",
@@ -11649,12 +11648,6 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "peer": true
-    },
-    "node_modules/@types/remove-markdown": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/@types/remove-markdown/-/remove-markdown-0.3.4.tgz",
-      "integrity": "sha512-i753EH/p02bw7bLlpfS/4CV1rdikbGiLabWyVsAvsFid3cA5RNU1frG7JycgY+NSnFwtoGlElvZVceCytecTDA==",
-      "dev": true
     },
     "node_modules/@types/scheduler": {
       "version": "0.16.2",

--- a/package.json
+++ b/package.json
@@ -92,7 +92,6 @@
     "@testing-library/react": "^14.2.1",
     "@types/react": "^18.0.17",
     "@types/react-dom": "^18.0.6",
-    "@types/remove-markdown": "^0.3.4",
     "@typescript-eslint/eslint-plugin": "^6.19.0",
     "@typescript-eslint/parser": "^6.19.0",
     "@vitejs/plugin-react": "^4.2.1",

--- a/src/components/ui/proposal/Markdown.tsx
+++ b/src/components/ui/proposal/Markdown.tsx
@@ -89,7 +89,7 @@ export default function Markdown({ truncate, content, collapsedLines = 6 }: IMar
         maxWidth="100%"
       >
         <ReactMarkdown
-          remarkPlugins={[remarkGfm]}
+          remarkPlugins={truncate ? [] : [remarkGfm]}
           urlTransform={handleTransformURI}
           components={MarkdownComponents}
           className="markdown-body"

--- a/src/hooks/DAO/loaders/governance/useAzoriusListeners.ts
+++ b/src/hooks/DAO/loaders/governance/useAzoriusListeners.ts
@@ -1,5 +1,6 @@
 import { LinearERC20Voting, LinearERC721Voting } from '@fractal-framework/fractal-contracts';
 import { TypedListener } from '@fractal-framework/fractal-contracts/dist/typechain-types/common';
+import { TimelockPeriodUpdatedEvent } from '@fractal-framework/fractal-contracts/dist/typechain-types/contracts/MultisigFreezeGuard';
 import {
   Azorius,
   ProposalCreatedEvent,
@@ -26,7 +27,6 @@ import {
 import { getAverageBlockTime } from '../../../../utils/contract';
 import useSafeContracts from '../../../safe/useSafeContracts';
 import { useSafeDecoder } from '../../../utils/useSafeDecoder';
-import { TimelockPeriodUpdatedEvent } from '@fractal-framework/fractal-contracts/dist/typechain-types/contracts/MultisigFreezeGuard';
 
 const proposalCreatedEventListener = (
   azoriusContract: Azorius,

--- a/src/hooks/DAO/loaders/governance/useAzoriusProposalListeners.ts
+++ b/src/hooks/DAO/loaders/governance/useAzoriusProposalListeners.ts
@@ -36,7 +36,6 @@ const proposalCreatedEventListener = (
   dispatch: Dispatch<FractalActions>,
 ): TypedListener<ProposalCreatedEvent> => {
   return async (_strategyAddress, proposalId, proposer, transactions, metadata) => {
-    console.log({ metadata });
     if (!metadata) {
       return;
     }
@@ -65,8 +64,6 @@ const proposalCreatedEventListener = (
       Promise.resolve(undefined),
       proposalData,
     );
-
-    console.log({ proposal });
 
     dispatch({
       type: FractalGovernanceAction.UPDATE_PROPOSALS_NEW,
@@ -219,11 +216,9 @@ export const useAzoriusProposalListeners = () => {
     const votedEvent = erc20StrategyContract.filters.Voted();
     const listener = erc20VotedEventListener(erc20StrategyContract, strategyType, action.dispatch);
 
-    console.log('creating erc20 voted listener');
     erc20StrategyContract.on(votedEvent, listener);
 
     return () => {
-      console.log('removing erc20 voted listener');
       erc20StrategyContract.off(votedEvent, listener);
     };
   }, [action.dispatch, erc20StrategyContract, strategyType]);

--- a/src/hooks/DAO/loaders/governance/useAzoriusProposalListeners.ts
+++ b/src/hooks/DAO/loaders/governance/useAzoriusProposalListeners.ts
@@ -1,0 +1,249 @@
+import { LinearERC20Voting, LinearERC721Voting } from '@fractal-framework/fractal-contracts';
+import { TypedListener } from '@fractal-framework/fractal-contracts/dist/typechain-types/common';
+import {
+  Azorius,
+  ProposalCreatedEvent,
+} from '@fractal-framework/fractal-contracts/dist/typechain-types/contracts/azorius/Azorius';
+import { VotedEvent as ERC20VotedEvent } from '@fractal-framework/fractal-contracts/dist/typechain-types/contracts/azorius/LinearERC20Voting';
+import { VotedEvent as ERC721VotedEvent } from '@fractal-framework/fractal-contracts/dist/typechain-types/contracts/azorius/LinearERC721Voting';
+import { BigNumber } from 'ethers';
+import { Dispatch, useEffect, useMemo } from 'react';
+import { useFractal } from '../../../../providers/App/AppProvider';
+import { FractalGovernanceAction } from '../../../../providers/App/governance/action';
+import { useEthersProvider } from '../../../../providers/Ethers/hooks/useEthersProvider';
+import {
+  ProposalMetadata,
+  VotingStrategyType,
+  DecodedTransaction,
+  FractalActions,
+} from '../../../../types';
+import { Providers } from '../../../../types/network';
+import {
+  getProposalVotesSummary,
+  mapProposalCreatedEventToProposal,
+  decodeTransactions,
+} from '../../../../utils';
+import useSafeContracts from '../../../safe/useSafeContracts';
+import { useSafeDecoder } from '../../../utils/useSafeDecoder';
+
+const proposalCreatedEventListener = (
+  azoriusContract: Azorius,
+  erc20StrategyContract: LinearERC20Voting | undefined,
+  erc721StrategyContract: LinearERC721Voting | undefined,
+  provider: Providers,
+  strategyType: VotingStrategyType,
+  decode: (value: string, to: string, data?: string | undefined) => Promise<DecodedTransaction[]>,
+  dispatch: Dispatch<FractalActions>,
+): TypedListener<ProposalCreatedEvent> => {
+  return async (_strategyAddress, proposalId, proposer, transactions, metadata) => {
+    console.log({ metadata });
+    if (!metadata) {
+      return;
+    }
+
+    const metaDataEvent: ProposalMetadata = JSON.parse(metadata);
+    const proposalData = {
+      metaData: {
+        title: metaDataEvent.title,
+        description: metaDataEvent.description,
+        documentationUrl: metaDataEvent.documentationUrl,
+      },
+      transactions: transactions,
+      decodedTransactions: await decodeTransactions(decode, transactions),
+    };
+
+    const proposal = await mapProposalCreatedEventToProposal(
+      erc20StrategyContract,
+      erc721StrategyContract,
+      strategyType,
+      proposalId,
+      proposer,
+      azoriusContract,
+      provider,
+      Promise.resolve(undefined),
+      Promise.resolve(undefined),
+      Promise.resolve(undefined),
+      proposalData,
+    );
+
+    console.log({ proposal });
+
+    dispatch({
+      type: FractalGovernanceAction.UPDATE_PROPOSALS_NEW,
+      payload: proposal,
+    });
+  };
+};
+
+const erc20VotedEventListener = (
+  erc20StrategyContract: LinearERC20Voting,
+  strategyType: VotingStrategyType,
+  dispatch: Dispatch<FractalActions>,
+): TypedListener<ERC20VotedEvent> => {
+  return async (voter, proposalId, voteType, weight) => {
+    const votesSummary = await getProposalVotesSummary(
+      erc20StrategyContract,
+      undefined,
+      strategyType,
+      BigNumber.from(proposalId),
+    );
+
+    dispatch({
+      type: FractalGovernanceAction.UPDATE_NEW_AZORIUS_ERC20_VOTE,
+      payload: {
+        proposalId: proposalId.toString(),
+        voter,
+        support: voteType,
+        weight,
+        votesSummary,
+      },
+    });
+  };
+};
+
+const erc721VotedEventListener = (
+  erc721StrategyContract: LinearERC721Voting,
+  strategyType: VotingStrategyType,
+  dispatch: Dispatch<FractalActions>,
+): TypedListener<ERC721VotedEvent> => {
+  return async (voter, proposalId, voteType, tokenAddresses, tokenIds) => {
+    const votesSummary = await getProposalVotesSummary(
+      undefined,
+      erc721StrategyContract,
+      strategyType,
+      BigNumber.from(proposalId),
+    );
+
+    dispatch({
+      type: FractalGovernanceAction.UPDATE_NEW_AZORIUS_ERC721_VOTE,
+      payload: {
+        proposalId: proposalId.toString(),
+        voter,
+        support: voteType,
+        tokenAddresses,
+        tokenIds: tokenIds.map(tokenId => tokenId.toString()),
+        votesSummary,
+      },
+    });
+  };
+};
+
+export const useAzoriusProposalListeners = () => {
+  const {
+    action,
+    governanceContracts: {
+      azoriusContractAddress,
+      ozLinearVotingContractAddress,
+      erc721LinearVotingContractAddress,
+    },
+  } = useFractal();
+
+  const baseContracts = useSafeContracts();
+  const provider = useEthersProvider();
+  const decode = useSafeDecoder();
+
+  const azoriusContract = useMemo(() => {
+    if (!baseContracts || !azoriusContractAddress) {
+      return;
+    }
+
+    return baseContracts.fractalAzoriusMasterCopyContract.asProvider.attach(azoriusContractAddress);
+  }, [azoriusContractAddress, baseContracts]);
+
+  const strategyType = useMemo(() => {
+    if (ozLinearVotingContractAddress) {
+      return VotingStrategyType.LINEAR_ERC20;
+    } else if (erc721LinearVotingContractAddress) {
+      return VotingStrategyType.LINEAR_ERC721;
+    } else {
+      return undefined;
+    }
+  }, [ozLinearVotingContractAddress, erc721LinearVotingContractAddress]);
+
+  const erc20StrategyContract = useMemo(() => {
+    if (!baseContracts || !ozLinearVotingContractAddress) {
+      return undefined;
+    }
+
+    return baseContracts.linearVotingMasterCopyContract.asProvider.attach(
+      ozLinearVotingContractAddress,
+    );
+  }, [baseContracts, ozLinearVotingContractAddress]);
+
+  const erc721StrategyContract = useMemo(() => {
+    if (!baseContracts || !erc721LinearVotingContractAddress) {
+      return undefined;
+    }
+
+    return baseContracts.linearVotingERC721MasterCopyContract.asProvider.attach(
+      erc721LinearVotingContractAddress,
+    );
+  }, [baseContracts, erc721LinearVotingContractAddress]);
+
+  useEffect(() => {
+    if (!azoriusContract || !provider || !strategyType) {
+      return;
+    }
+
+    const proposalCreatedFilter = azoriusContract.filters.ProposalCreated();
+    const listener = proposalCreatedEventListener(
+      azoriusContract,
+      erc20StrategyContract,
+      erc721StrategyContract,
+      provider,
+      strategyType,
+      decode,
+      action.dispatch,
+    );
+
+    azoriusContract.on(proposalCreatedFilter, listener);
+
+    return () => {
+      azoriusContract.off(proposalCreatedFilter, listener);
+    };
+  }, [
+    action.dispatch,
+    azoriusContract,
+    decode,
+    erc20StrategyContract,
+    erc721StrategyContract,
+    provider,
+    strategyType,
+  ]);
+
+  useEffect(() => {
+    if (strategyType !== VotingStrategyType.LINEAR_ERC20 || !erc20StrategyContract) {
+      return;
+    }
+
+    const votedEvent = erc20StrategyContract.filters.Voted();
+    const listener = erc20VotedEventListener(erc20StrategyContract, strategyType, action.dispatch);
+
+    console.log('creating erc20 voted listener');
+    erc20StrategyContract.on(votedEvent, listener);
+
+    return () => {
+      console.log('removing erc20 voted listener');
+      erc20StrategyContract.off(votedEvent, listener);
+    };
+  }, [action.dispatch, erc20StrategyContract, strategyType]);
+
+  useEffect(() => {
+    if (strategyType !== VotingStrategyType.LINEAR_ERC721 || !erc721StrategyContract) {
+      return;
+    }
+
+    const votedEvent = erc721StrategyContract.filters.Voted();
+    const listener = erc721VotedEventListener(
+      erc721StrategyContract,
+      strategyType,
+      action.dispatch,
+    );
+
+    erc721StrategyContract.on(votedEvent, listener);
+
+    return () => {
+      erc721StrategyContract.off(votedEvent, listener);
+    };
+  }, [action.dispatch, erc721StrategyContract, strategyType]);
+};

--- a/src/hooks/DAO/loaders/governance/useAzoriusProposals.ts
+++ b/src/hooks/DAO/loaders/governance/useAzoriusProposals.ts
@@ -113,14 +113,7 @@ export const useAzoriusProposals = () => {
       );
     };
 
-    const loadProposalSynchronously = async (
-      _proposalCreatedEvents: ProposalCreatedEvent[],
-      _loadProposalFromEvent: (
-        { args }: ProposalCreatedEvent,
-        votedEvents: VotedEvent[],
-        executedEvents: ProposalExecutedEvent[],
-      ) => Promise<AzoriusProposal>,
-    ) => {
+    const loadProposalsSynchronously = async (_proposalCreatedEvents: ProposalCreatedEvent[]) => {
       const votedEventFilter = strategyContract.filters.Voted();
       const votedEvents = await strategyContract.queryFilter(votedEventFilter);
 
@@ -128,7 +121,7 @@ export const useAzoriusProposals = () => {
       const executedEvents = await azoriusContract.queryFilter(executedEventFilter);
 
       for (const proposalCreatedEvent of _proposalCreatedEvents) {
-        const proposal = await _loadProposalFromEvent(
+        const proposal = await loadProposalFromEvent(
           proposalCreatedEvent,
           votedEvents,
           executedEvents,
@@ -140,7 +133,7 @@ export const useAzoriusProposals = () => {
       }
     };
 
-    await loadProposalSynchronously(proposalCreatedEvents.reverse(), loadProposalFromEvent);
+    await loadProposalsSynchronously(proposalCreatedEvents.reverse());
   }, [
     azoriusContractAddress,
     ozLinearVotingContractAddress,

--- a/src/hooks/DAO/loaders/governance/useAzoriusProposals.ts
+++ b/src/hooks/DAO/loaders/governance/useAzoriusProposals.ts
@@ -157,20 +157,18 @@ export const useAzoriusProposals = () => {
     return undefined;
   }
 
-  return {
-    loadAzoriusProposals: (proposalLoaded: (proposal: AzoriusProposal) => void) => {
-      return loadAzoriusProposals(
-        azoriusContract,
-        erc20StrategyContract,
-        erc721StrategyContract,
-        strategyType,
-        provider,
-        erc20VotedEvents,
-        erc721VotedEvents,
-        executedEvents,
-        decode,
-        proposalLoaded,
-      );
-    },
+  return (proposalLoaded: (proposal: AzoriusProposal) => void) => {
+    return loadAzoriusProposals(
+      azoriusContract,
+      erc20StrategyContract,
+      erc721StrategyContract,
+      strategyType,
+      provider,
+      erc20VotedEvents,
+      erc721VotedEvents,
+      executedEvents,
+      decode,
+      proposalLoaded,
+    );
   };
 };

--- a/src/hooks/DAO/loaders/governance/useAzoriusProposals.ts
+++ b/src/hooks/DAO/loaders/governance/useAzoriusProposals.ts
@@ -116,184 +116,184 @@ export const useAzoriusProposals = () => {
     baseContracts,
   ]);
 
-  const { requestWithRetries } = useAsyncRetry();
-  // Azrious proposals are listeners
-  const proposalCreatedListener: TypedListener<ProposalCreatedEvent> = useCallback(
-    async (strategyAddress, proposalId, proposer, transactions, _metadata) => {
-      if (
-        !azoriusContractAddress ||
-        !(ozLinearVotingContractAddress || erc721LinearVotingContractAddress) ||
-        !strategyType ||
-        !provider ||
-        !baseContracts
-      ) {
-        return;
-      }
-      let proposalData: ProposalData | undefined;
-      const azoriusContract =
-        baseContracts.fractalAzoriusMasterCopyContract.asProvider.attach(azoriusContractAddress);
-      if (_metadata) {
-        const metaDataEvent: ProposalMetadata = JSON.parse(_metadata);
-        proposalData = {
-          metaData: {
-            title: metaDataEvent.title,
-            description: metaDataEvent.description,
-            documentationUrl: metaDataEvent.documentationUrl,
-          },
-          transactions: transactions,
-          decodedTransactions: await decodeTransactions(transactions),
-        };
-      }
-      let strategyContract: LinearERC20Voting | LinearERC721Voting;
-      if (ozLinearVotingContractAddress) {
-        strategyContract =
-          baseContracts.linearVotingMasterCopyContract.asProvider.attach(strategyAddress);
-      } else if (erc721LinearVotingContractAddress) {
-        strategyContract =
-          baseContracts.linearVotingERC721MasterCopyContract.asProvider.attach(strategyAddress);
-      } else {
-        logError('No strategy contract found');
-        return [];
-      }
-      const func = async () => {
-        return mapProposalCreatedEventToProposal(
-          strategyContract,
-          strategyType,
-          proposalId,
-          proposer,
-          azoriusContract,
-          provider,
-          proposalData,
-        );
-      };
-      const proposal = await requestWithRetries(func, 5, 7000);
-      if (proposal) {
-        action.dispatch({
-          type: FractalGovernanceAction.UPDATE_PROPOSALS_NEW,
-          payload: proposal,
-        });
-      }
-    },
-    [
-      baseContracts,
-      azoriusContractAddress,
-      provider,
-      decodeTransactions,
-      action,
-      requestWithRetries,
-      strategyType,
-      ozLinearVotingContractAddress,
-      erc721LinearVotingContractAddress,
-    ],
-  );
+  // const { requestWithRetries } = useAsyncRetry();
+  // // Azrious proposals are listeners
+  // const proposalCreatedListener: TypedListener<ProposalCreatedEvent> = useCallback(
+  //   async (strategyAddress, proposalId, proposer, transactions, _metadata) => {
+  //     if (
+  //       !azoriusContractAddress ||
+  //       !(ozLinearVotingContractAddress || erc721LinearVotingContractAddress) ||
+  //       !strategyType ||
+  //       !provider ||
+  //       !baseContracts
+  //     ) {
+  //       return;
+  //     }
+  //     let proposalData: ProposalData | undefined;
+  //     const azoriusContract =
+  //       baseContracts.fractalAzoriusMasterCopyContract.asProvider.attach(azoriusContractAddress);
+  //     if (_metadata) {
+  //       const metaDataEvent: ProposalMetadata = JSON.parse(_metadata);
+  //       proposalData = {
+  //         metaData: {
+  //           title: metaDataEvent.title,
+  //           description: metaDataEvent.description,
+  //           documentationUrl: metaDataEvent.documentationUrl,
+  //         },
+  //         transactions: transactions,
+  //         decodedTransactions: await decodeTransactions(transactions),
+  //       };
+  //     }
+  //     let strategyContract: LinearERC20Voting | LinearERC721Voting;
+  //     if (ozLinearVotingContractAddress) {
+  //       strategyContract =
+  //         baseContracts.linearVotingMasterCopyContract.asProvider.attach(strategyAddress);
+  //     } else if (erc721LinearVotingContractAddress) {
+  //       strategyContract =
+  //         baseContracts.linearVotingERC721MasterCopyContract.asProvider.attach(strategyAddress);
+  //     } else {
+  //       logError('No strategy contract found');
+  //       return [];
+  //     }
+  //     const func = async () => {
+  //       return mapProposalCreatedEventToProposal(
+  //         strategyContract,
+  //         strategyType,
+  //         proposalId,
+  //         proposer,
+  //         azoriusContract,
+  //         provider,
+  //         proposalData,
+  //       );
+  //     };
+  //     const proposal = await requestWithRetries(func, 5, 7000);
+  //     if (proposal) {
+  //       action.dispatch({
+  //         type: FractalGovernanceAction.UPDATE_PROPOSALS_NEW,
+  //         payload: proposal,
+  //       });
+  //     }
+  //   },
+  //   [
+  //     baseContracts,
+  //     azoriusContractAddress,
+  //     provider,
+  //     decodeTransactions,
+  //     action,
+  //     requestWithRetries,
+  //     strategyType,
+  //     ozLinearVotingContractAddress,
+  //     erc721LinearVotingContractAddress,
+  //   ],
+  // );
 
-  const erc20ProposalVotedEventListener: TypedListener<ERC20VotedEvent> = useCallback(
-    async (voter, proposalId, support, weight) => {
-      if (!ozLinearVotingContractAddress || !strategyType || !baseContracts) {
-        return;
-      }
-      const strategyContract = baseContracts.linearVotingMasterCopyContract.asProvider.attach(
-        ozLinearVotingContractAddress,
-      );
+  // const erc20ProposalVotedEventListener: TypedListener<ERC20VotedEvent> = useCallback(
+  //   async (voter, proposalId, support, weight) => {
+  //     if (!ozLinearVotingContractAddress || !strategyType || !baseContracts) {
+  //       return;
+  //     }
+  //     const strategyContract = baseContracts.linearVotingMasterCopyContract.asProvider.attach(
+  //       ozLinearVotingContractAddress,
+  //     );
 
-      const votesSummary = await getProposalVotesSummary(
-        strategyContract,
-        strategyType,
-        BigNumber.from(proposalId),
-      );
+  //     const votesSummary = await getProposalVotesSummary(
+  //       strategyContract,
+  //       strategyType,
+  //       BigNumber.from(proposalId),
+  //     );
 
-      action.dispatch({
-        type: FractalGovernanceAction.UPDATE_NEW_AZORIUS_ERC20_VOTE,
-        payload: {
-          proposalId: proposalId.toString(),
-          voter,
-          support,
-          weight,
-          votesSummary,
-        },
-      });
-    },
-    [ozLinearVotingContractAddress, action, strategyType, baseContracts],
-  );
+  //     action.dispatch({
+  //       type: FractalGovernanceAction.UPDATE_NEW_AZORIUS_ERC20_VOTE,
+  //       payload: {
+  //         proposalId: proposalId.toString(),
+  //         voter,
+  //         support,
+  //         weight,
+  //         votesSummary,
+  //       },
+  //     });
+  //   },
+  //   [ozLinearVotingContractAddress, action, strategyType, baseContracts],
+  // );
 
-  const erc721ProposalVotedEventListener: TypedListener<ERC721VotedEvent> = useCallback(
-    async (voter, proposalId, support, tokenAddresses, tokenIds) => {
-      if (!erc721LinearVotingContractAddress || !strategyType || !baseContracts) {
-        return;
-      }
-      const strategyContract = baseContracts.linearVotingMasterCopyContract.asProvider.attach(
-        erc721LinearVotingContractAddress,
-      );
-      const votesSummary = await getProposalVotesSummary(
-        strategyContract,
-        strategyType,
-        BigNumber.from(proposalId),
-      );
+  // const erc721ProposalVotedEventListener: TypedListener<ERC721VotedEvent> = useCallback(
+  //   async (voter, proposalId, support, tokenAddresses, tokenIds) => {
+  //     if (!erc721LinearVotingContractAddress || !strategyType || !baseContracts) {
+  //       return;
+  //     }
+  //     const strategyContract = baseContracts.linearVotingMasterCopyContract.asProvider.attach(
+  //       erc721LinearVotingContractAddress,
+  //     );
+  //     const votesSummary = await getProposalVotesSummary(
+  //       strategyContract,
+  //       strategyType,
+  //       BigNumber.from(proposalId),
+  //     );
 
-      action.dispatch({
-        type: FractalGovernanceAction.UPDATE_NEW_AZORIUS_ERC721_VOTE,
-        payload: {
-          proposalId: proposalId.toString(),
-          voter,
-          support,
-          tokenAddresses,
-          tokenIds: tokenIds.map(tokenId => tokenId.toString()),
-          votesSummary,
-        },
-      });
-    },
-    [erc721LinearVotingContractAddress, action, strategyType, baseContracts],
-  );
+  //     action.dispatch({
+  //       type: FractalGovernanceAction.UPDATE_NEW_AZORIUS_ERC721_VOTE,
+  //       payload: {
+  //         proposalId: proposalId.toString(),
+  //         voter,
+  //         support,
+  //         tokenAddresses,
+  //         tokenIds: tokenIds.map(tokenId => tokenId.toString()),
+  //         votesSummary,
+  //       },
+  //     });
+  //   },
+  //   [erc721LinearVotingContractAddress, action, strategyType, baseContracts],
+  // );
 
-  useEffect(() => {
-    if (!azoriusContractAddress || !baseContracts) {
-      return;
-    }
+  // useEffect(() => {
+  //   if (!azoriusContractAddress || !baseContracts) {
+  //     return;
+  //   }
 
-    const azoriusContract =
-      baseContracts.fractalAzoriusMasterCopyContract.asProvider.attach(azoriusContractAddress);
-    const proposalCreatedFilter = azoriusContract.filters.ProposalCreated();
+  //   const azoriusContract =
+  //     baseContracts.fractalAzoriusMasterCopyContract.asProvider.attach(azoriusContractAddress);
+  //   const proposalCreatedFilter = azoriusContract.filters.ProposalCreated();
 
-    azoriusContract.on(proposalCreatedFilter, proposalCreatedListener);
+  //   azoriusContract.on(proposalCreatedFilter, proposalCreatedListener);
 
-    return () => {
-      azoriusContract.off(proposalCreatedFilter, proposalCreatedListener);
-    };
-  }, [azoriusContractAddress, proposalCreatedListener, baseContracts]);
+  //   return () => {
+  //     azoriusContract.off(proposalCreatedFilter, proposalCreatedListener);
+  //   };
+  // }, [azoriusContractAddress, proposalCreatedListener, baseContracts]);
 
-  useEffect(() => {
-    if (ozLinearVotingContractAddress && baseContracts) {
-      const ozLinearVotingContract = baseContracts.linearVotingMasterCopyContract.asProvider.attach(
-        ozLinearVotingContractAddress,
-      );
+  // useEffect(() => {
+  //   if (ozLinearVotingContractAddress && baseContracts) {
+  //     const ozLinearVotingContract = baseContracts.linearVotingMasterCopyContract.asProvider.attach(
+  //       ozLinearVotingContractAddress,
+  //     );
 
-      const votedEvent = ozLinearVotingContract.filters.Voted();
+  //     const votedEvent = ozLinearVotingContract.filters.Voted();
 
-      ozLinearVotingContract.on(votedEvent, erc20ProposalVotedEventListener);
+  //     ozLinearVotingContract.on(votedEvent, erc20ProposalVotedEventListener);
 
-      return () => {
-        ozLinearVotingContract.off(votedEvent, erc20ProposalVotedEventListener);
-      };
-    } else if (erc721LinearVotingContractAddress && baseContracts) {
-      const erc721LinearVotingContract =
-        baseContracts.linearVotingMasterCopyContract.asProvider.attach(
-          erc721LinearVotingContractAddress,
-        );
-      const votedEvent = erc721LinearVotingContract.filters.Voted();
+  //     return () => {
+  //       ozLinearVotingContract.off(votedEvent, erc20ProposalVotedEventListener);
+  //     };
+  //   } else if (erc721LinearVotingContractAddress && baseContracts) {
+  //     const erc721LinearVotingContract =
+  //       baseContracts.linearVotingMasterCopyContract.asProvider.attach(
+  //         erc721LinearVotingContractAddress,
+  //       );
+  //     const votedEvent = erc721LinearVotingContract.filters.Voted();
 
-      erc721LinearVotingContract.on(votedEvent, erc721ProposalVotedEventListener);
+  //     erc721LinearVotingContract.on(votedEvent, erc721ProposalVotedEventListener);
 
-      return () => {
-        erc721LinearVotingContract.off(votedEvent, erc721ProposalVotedEventListener);
-      };
-    }
-  }, [
-    ozLinearVotingContractAddress,
-    erc721LinearVotingContractAddress,
-    erc20ProposalVotedEventListener,
-    erc721ProposalVotedEventListener,
-    baseContracts,
-  ]);
+  //     return () => {
+  //       erc721LinearVotingContract.off(votedEvent, erc721ProposalVotedEventListener);
+  //     };
+  //   }
+  // }, [
+  //   ozLinearVotingContractAddress,
+  //   erc721LinearVotingContractAddress,
+  //   erc20ProposalVotedEventListener,
+  //   erc721ProposalVotedEventListener,
+  //   baseContracts,
+  // ]);
 
   return loadAzoriusProposals;
 };

--- a/src/hooks/DAO/loaders/governance/useAzoriusProposals.ts
+++ b/src/hooks/DAO/loaders/governance/useAzoriusProposals.ts
@@ -1,5 +1,4 @@
 import { LinearERC20Voting, LinearERC721Voting } from '@fractal-framework/fractal-contracts';
-import { TypedListener } from '@fractal-framework/fractal-contracts/dist/typechain-types/common';
 import {
   Azorius,
   ProposalExecutedEvent,
@@ -7,31 +6,15 @@ import {
 } from '@fractal-framework/fractal-contracts/dist/typechain-types/contracts/azorius/Azorius';
 import { VotedEvent as ERC20VotedEvent } from '@fractal-framework/fractal-contracts/dist/typechain-types/contracts/azorius/LinearERC20Voting';
 import { VotedEvent as ERC721VotedEvent } from '@fractal-framework/fractal-contracts/dist/typechain-types/contracts/azorius/LinearERC721Voting';
-import { BigNumber } from 'ethers';
-import { useEffect, useMemo } from 'react';
+import { useMemo } from 'react';
 import { useFractal } from '../../../../providers/App/AppProvider';
 import { useEthersProvider } from '../../../../providers/Ethers/hooks/useEthersProvider';
-import {
-  ProposalMetadata,
-  MetaTransaction,
-  VotingStrategyType,
-  DecodedTransaction,
-} from '../../../../types';
-import { AzoriusProposal, ProposalVotesSummary } from '../../../../types/daoProposal';
+import { ProposalMetadata, VotingStrategyType, DecodedTransaction } from '../../../../types';
+import { AzoriusProposal } from '../../../../types/daoProposal';
 import { Providers } from '../../../../types/network';
-import { getProposalVotesSummary, mapProposalCreatedEventToProposal } from '../../../../utils';
+import { mapProposalCreatedEventToProposal, decodeTransactions } from '../../../../utils';
 import useSafeContracts from '../../../safe/useSafeContracts';
 import { useSafeDecoder } from '../../../utils/useSafeDecoder';
-
-const decodeTransactions = async (
-  _decode: (value: string, to: string, data?: string | undefined) => Promise<DecodedTransaction[]>,
-  _transactions: MetaTransaction[],
-) => {
-  const decodedTransactions = await Promise.all(
-    _transactions.map(async tx => _decode(tx.value.toString(), tx.to, tx.data)),
-  );
-  return decodedTransactions.flat();
-};
 
 const loadProposalFromEvent = async (
   _provider: Providers,
@@ -112,118 +95,7 @@ const loadAzoriusProposals = async (
   }
 };
 
-const proposalCreatedEventListener = (
-  azoriusContract: Azorius,
-  erc20StrategyContract: LinearERC20Voting | undefined,
-  erc721StrategyContract: LinearERC721Voting | undefined,
-  erc20VotedEvents: Promise<ERC20VotedEvent[] | undefined>,
-  erc721VotedEvents: Promise<ERC721VotedEvent[] | undefined>,
-  executedEvents: Promise<ProposalExecutedEvent[] | undefined>,
-  provider: Providers,
-  strategyType: VotingStrategyType,
-  decode: (value: string, to: string, data?: string | undefined) => Promise<DecodedTransaction[]>,
-  callback: (proposal: AzoriusProposal) => void,
-): TypedListener<ProposalCreatedEvent> => {
-  return async (_strategyAddress, proposalId, proposer, transactions, metadata) => {
-    console.log({ metadata });
-    if (!metadata) {
-      return;
-    }
-
-    const metaDataEvent: ProposalMetadata = JSON.parse(metadata);
-    const proposalData = {
-      metaData: {
-        title: metaDataEvent.title,
-        description: metaDataEvent.description,
-        documentationUrl: metaDataEvent.documentationUrl,
-      },
-      transactions: transactions,
-      decodedTransactions: await decodeTransactions(decode, transactions),
-    };
-
-    const proposal = await mapProposalCreatedEventToProposal(
-      erc20StrategyContract,
-      erc721StrategyContract,
-      strategyType,
-      proposalId,
-      proposer,
-      azoriusContract,
-      provider,
-      erc20VotedEvents,
-      erc721VotedEvents,
-      executedEvents,
-      proposalData,
-    );
-
-    console.log({ proposal });
-
-    callback(proposal);
-  };
-};
-
-const erc20VotedEventListener = (
-  erc20StrategyContract: LinearERC20Voting,
-  strategyType: VotingStrategyType,
-  callback: (
-    proposalId: number,
-    voter: string,
-    voteType: number,
-    weight: BigNumber,
-    votesSummary: ProposalVotesSummary,
-  ) => void,
-): TypedListener<ERC20VotedEvent> => {
-  return async (voter, proposalId, voteType, weight) => {
-    const votesSummary = await getProposalVotesSummary(
-      erc20StrategyContract,
-      undefined,
-      strategyType,
-      BigNumber.from(proposalId),
-    );
-    callback(proposalId, voter, voteType, weight, votesSummary);
-  };
-};
-
-const erc721VotedEventListener = (
-  erc721StrategyContract: LinearERC721Voting,
-  strategyType: VotingStrategyType,
-  callback: (
-    proposalId: number,
-    voter: string,
-    voteType: number,
-    tokenAddresses: string[],
-    tokenIds: BigNumber[],
-    votesSummary: ProposalVotesSummary,
-  ) => void,
-): TypedListener<ERC721VotedEvent> => {
-  return async (voter, proposalId, voteType, tokenAddresses, tokenIds) => {
-    const votesSummary = await getProposalVotesSummary(
-      undefined,
-      erc721StrategyContract,
-      strategyType,
-      BigNumber.from(proposalId),
-    );
-    callback(proposalId, voter, voteType, tokenAddresses, tokenIds, votesSummary);
-  };
-};
-
-export const useAzoriusProposals = (
-  proposalCreatedEventCallback: (proposal: AzoriusProposal) => void,
-  erc20VotedEventCallback: (
-    proposalId: number,
-    voter: string,
-    support: number,
-    weight: BigNumber,
-    votesSummary: ProposalVotesSummary,
-  ) => void,
-  erc721VotedEventCallback: (
-    proposalId: number,
-    voter: string,
-    support: number,
-    tokenAddresses: string[],
-    tokenIds: BigNumber[],
-    votesSummary: ProposalVotesSummary,
-  ) => void,
-) => {
+export const useAzoriusProposals = () => {
   const {
     governanceContracts: {
       azoriusContractAddress,
@@ -306,81 +178,6 @@ export const useAzoriusProposals = (
 
     return events;
   }, [azoriusContract]);
-
-  useEffect(() => {
-    if (!azoriusContract || !provider || !strategyType) {
-      return;
-    }
-
-    const proposalCreatedFilter = azoriusContract.filters.ProposalCreated();
-    const listener = proposalCreatedEventListener(
-      azoriusContract,
-      erc20StrategyContract,
-      erc721StrategyContract,
-      erc20VotedEvents,
-      erc721VotedEvents,
-      executedEvents,
-      provider,
-      strategyType,
-      decode,
-      proposalCreatedEventCallback,
-    );
-
-    azoriusContract.on(proposalCreatedFilter, listener);
-
-    return () => {
-      azoriusContract.off(proposalCreatedFilter, listener);
-    };
-  }, [
-    azoriusContract,
-    decode,
-    erc20StrategyContract,
-    erc20VotedEvents,
-    erc721StrategyContract,
-    erc721VotedEvents,
-    executedEvents,
-    proposalCreatedEventCallback,
-    provider,
-    strategyType,
-  ]);
-
-  useEffect(() => {
-    if (strategyType !== VotingStrategyType.LINEAR_ERC20 || !erc20StrategyContract) {
-      return;
-    }
-
-    const votedEvent = erc20StrategyContract.filters.Voted();
-    const listener = erc20VotedEventListener(
-      erc20StrategyContract as LinearERC20Voting,
-      strategyType,
-      erc20VotedEventCallback,
-    );
-
-    erc20StrategyContract.on(votedEvent, listener);
-
-    return () => {
-      erc20StrategyContract.off(votedEvent, listener);
-    };
-  }, [erc20VotedEventCallback, erc20StrategyContract, strategyType]);
-
-  useEffect(() => {
-    if (strategyType !== VotingStrategyType.LINEAR_ERC721 || !erc721StrategyContract) {
-      return;
-    }
-
-    const votedEvent = erc721StrategyContract.filters.Voted();
-    const listener = erc721VotedEventListener(
-      erc721StrategyContract,
-      strategyType,
-      erc721VotedEventCallback,
-    );
-
-    erc721StrategyContract.on(votedEvent, listener);
-
-    return () => {
-      erc721StrategyContract.off(votedEvent, listener);
-    };
-  }, [erc721VotedEventCallback, erc721StrategyContract, strategyType]);
 
   if (!azoriusContract || !strategyType || !provider) {
     return undefined;

--- a/src/hooks/DAO/loaders/governance/useERC20LinearStrategy.ts
+++ b/src/hooks/DAO/loaders/governance/useERC20LinearStrategy.ts
@@ -1,5 +1,4 @@
 import { TypedListener } from '@fractal-framework/fractal-contracts/dist/typechain-types/common';
-import { TimelockPeriodUpdatedEvent } from '@fractal-framework/fractal-contracts/dist/typechain-types/contracts/MultisigFreezeGuard';
 import { QuorumNumeratorUpdatedEvent } from '@fractal-framework/fractal-contracts/dist/typechain-types/contracts/azorius/BaseQuorumPercent';
 import { VotingPeriodUpdatedEvent } from '@fractal-framework/fractal-contracts/dist/typechain-types/contracts/azorius/LinearERC20Voting';
 import { BigNumber } from 'ethers';

--- a/src/hooks/DAO/loaders/governance/useERC20LinearStrategy.ts
+++ b/src/hooks/DAO/loaders/governance/useERC20LinearStrategy.ts
@@ -109,25 +109,5 @@ export const useERC20LinearStrategy = () => {
     };
   }, [ozLinearVotingContractAddress, action, baseContracts]);
 
-  useEffect(() => {
-    if (!azoriusContractAddress || !baseContracts) {
-      return;
-    }
-    const azoriusContract =
-      baseContracts.fractalAzoriusMasterCopyContract.asProvider.attach(azoriusContractAddress);
-
-    const timeLockPeriodFilter = azoriusContract.filters.TimelockPeriodUpdated();
-    const timelockPeriodListener: TypedListener<TimelockPeriodUpdatedEvent> = timelockPeriod => {
-      action.dispatch({
-        type: FractalGovernanceAction.UPDATE_TIMELOCK_PERIOD,
-        payload: BigNumber.from(timelockPeriod),
-      });
-    };
-    azoriusContract.on(timeLockPeriodFilter, timelockPeriodListener);
-    return () => {
-      azoriusContract.off(timeLockPeriodFilter, timelockPeriodListener);
-    };
-  }, [azoriusContractAddress, action, baseContracts]);
-
   return loadERC20Strategy;
 };

--- a/src/hooks/DAO/loaders/governance/useERC20LinearStrategy.ts
+++ b/src/hooks/DAO/loaders/governance/useERC20LinearStrategy.ts
@@ -14,7 +14,6 @@ import { useTimeHelpers } from '../../../utils/useTimeHelpers';
 
 export const useERC20LinearStrategy = () => {
   const {
-    governance: { type },
     governanceContracts: { ozLinearVotingContractAddress, azoriusContractAddress },
     action,
   } = useFractal();
@@ -68,7 +67,7 @@ export const useERC20LinearStrategy = () => {
   ]);
 
   useEffect(() => {
-    if (!ozLinearVotingContractAddress || !baseContracts || !type) {
+    if (!ozLinearVotingContractAddress || !baseContracts) {
       return;
     }
     const ozLinearVotingContract = baseContracts.linearVotingMasterCopyContract.asProvider.attach(
@@ -86,10 +85,10 @@ export const useERC20LinearStrategy = () => {
     return () => {
       ozLinearVotingContract.off(votingPeriodfilter, listener);
     };
-  }, [ozLinearVotingContractAddress, action, baseContracts, type]);
+  }, [ozLinearVotingContractAddress, action, baseContracts]);
 
   useEffect(() => {
-    if (!ozLinearVotingContractAddress || !baseContracts || !type) {
+    if (!ozLinearVotingContractAddress || !baseContracts) {
       return;
     }
     const ozLinearVotingContract = baseContracts.linearVotingMasterCopyContract.asProvider.attach(
@@ -108,14 +107,15 @@ export const useERC20LinearStrategy = () => {
     return () => {
       ozLinearVotingContract.off(quorumNumeratorUpdatedFilter, quorumNumeratorUpdatedListener);
     };
-  }, [ozLinearVotingContractAddress, action, baseContracts, type]);
+  }, [ozLinearVotingContractAddress, action, baseContracts]);
 
   useEffect(() => {
-    if (!azoriusContractAddress || !baseContracts || !type) {
+    if (!azoriusContractAddress || !baseContracts) {
       return;
     }
     const azoriusContract =
       baseContracts.fractalAzoriusMasterCopyContract.asProvider.attach(azoriusContractAddress);
+
     const timeLockPeriodFilter = azoriusContract.filters.TimelockPeriodUpdated();
     const timelockPeriodListener: TypedListener<TimelockPeriodUpdatedEvent> = timelockPeriod => {
       action.dispatch({
@@ -127,7 +127,7 @@ export const useERC20LinearStrategy = () => {
     return () => {
       azoriusContract.off(timeLockPeriodFilter, timelockPeriodListener);
     };
-  }, [azoriusContractAddress, action, baseContracts, type]);
+  }, [azoriusContractAddress, action, baseContracts]);
 
   return loadERC20Strategy;
 };

--- a/src/hooks/DAO/loaders/governance/useERC721LinearStrategy.ts
+++ b/src/hooks/DAO/loaders/governance/useERC721LinearStrategy.ts
@@ -1,5 +1,4 @@
 import { TypedListener } from '@fractal-framework/fractal-contracts/dist/typechain-types/common';
-import { TimelockPeriodUpdatedEvent } from '@fractal-framework/fractal-contracts/dist/typechain-types/contracts/MultisigFreezeGuard';
 import {
   VotingPeriodUpdatedEvent,
   QuorumThresholdUpdatedEvent,
@@ -116,27 +115,6 @@ export const useERC721LinearStrategy = () => {
       erc721LinearVotingContract.off(quorumThresholdUpdatedFilter, quorumThresholdUpdatedListener);
     };
   }, [erc721LinearVotingContractAddress, action, baseContracts, type]);
-
-  // this is duplicated in useERC20LinearStrategy line for line
-  // useEffect(() => {
-  //   if (!azoriusContractAddress || !baseContracts) {
-  //     return;
-  //   }
-  //   const azoriusContract =
-  //     baseContracts.fractalAzoriusMasterCopyContract.asProvider.attach(azoriusContractAddress);
-
-  //   const timeLockPeriodFilter = azoriusContract.filters.TimelockPeriodUpdated();
-  //   const timelockPeriodListener: TypedListener<TimelockPeriodUpdatedEvent> = timelockPeriod => {
-  //     action.dispatch({
-  //       type: FractalGovernanceAction.UPDATE_TIMELOCK_PERIOD,
-  //       payload: BigNumber.from(timelockPeriod),
-  //     });
-  //   };
-  //   azoriusContract.on(timeLockPeriodFilter, timelockPeriodListener);
-  //   return () => {
-  //     azoriusContract.off(timeLockPeriodFilter, timelockPeriodListener);
-  //   };
-  // }, [azoriusContractAddress, action, baseContracts]);
 
   return loadERC721Strategy;
 };

--- a/src/hooks/DAO/loaders/governance/useERC721LinearStrategy.ts
+++ b/src/hooks/DAO/loaders/governance/useERC721LinearStrategy.ts
@@ -16,7 +16,6 @@ import { useTimeHelpers } from '../../../utils/useTimeHelpers';
 export const useERC721LinearStrategy = () => {
   const {
     governanceContracts: { erc721LinearVotingContractAddress, azoriusContractAddress },
-    governance: { type },
     action,
   } = useFractal();
   const provider = useEthersProvider();
@@ -72,7 +71,7 @@ export const useERC721LinearStrategy = () => {
   ]);
 
   useEffect(() => {
-    if (!erc721LinearVotingContractAddress || !baseContracts || !type) {
+    if (!erc721LinearVotingContractAddress || !baseContracts) {
       return;
     }
     const erc721LinearVotingContract =
@@ -90,10 +89,10 @@ export const useERC721LinearStrategy = () => {
     return () => {
       erc721LinearVotingContract.off(votingPeriodfilter, listener);
     };
-  }, [erc721LinearVotingContractAddress, action, baseContracts, type]);
+  }, [erc721LinearVotingContractAddress, action, baseContracts]);
 
   useEffect(() => {
-    if (!erc721LinearVotingContractAddress || !baseContracts || !type) {
+    if (!erc721LinearVotingContractAddress || !baseContracts) {
       return;
     }
     const erc721LinearVotingContract =
@@ -114,7 +113,7 @@ export const useERC721LinearStrategy = () => {
     return () => {
       erc721LinearVotingContract.off(quorumThresholdUpdatedFilter, quorumThresholdUpdatedListener);
     };
-  }, [erc721LinearVotingContractAddress, action, baseContracts, type]);
+  }, [erc721LinearVotingContractAddress, action, baseContracts]);
 
   return loadERC721Strategy;
 };

--- a/src/hooks/DAO/loaders/governance/useERC721LinearStrategy.ts
+++ b/src/hooks/DAO/loaders/governance/useERC721LinearStrategy.ts
@@ -117,25 +117,26 @@ export const useERC721LinearStrategy = () => {
     };
   }, [erc721LinearVotingContractAddress, action, baseContracts, type]);
 
-  useEffect(() => {
-    if (!azoriusContractAddress || !baseContracts || !type) {
-      return;
-    }
-    const azoriusContract =
-      baseContracts.fractalAzoriusMasterCopyContract.asProvider.attach(azoriusContractAddress);
+  // this is duplicated in useERC20LinearStrategy line for line
+  // useEffect(() => {
+  //   if (!azoriusContractAddress || !baseContracts) {
+  //     return;
+  //   }
+  //   const azoriusContract =
+  //     baseContracts.fractalAzoriusMasterCopyContract.asProvider.attach(azoriusContractAddress);
 
-    const timeLockPeriodFilter = azoriusContract.filters.TimelockPeriodUpdated();
-    const timelockPeriodListener: TypedListener<TimelockPeriodUpdatedEvent> = timelockPeriod => {
-      action.dispatch({
-        type: FractalGovernanceAction.UPDATE_TIMELOCK_PERIOD,
-        payload: BigNumber.from(timelockPeriod),
-      });
-    };
-    azoriusContract.on(timeLockPeriodFilter, timelockPeriodListener);
-    return () => {
-      azoriusContract.off(timeLockPeriodFilter, timelockPeriodListener);
-    };
-  }, [azoriusContractAddress, action, baseContracts, type]);
+  //   const timeLockPeriodFilter = azoriusContract.filters.TimelockPeriodUpdated();
+  //   const timelockPeriodListener: TypedListener<TimelockPeriodUpdatedEvent> = timelockPeriod => {
+  //     action.dispatch({
+  //       type: FractalGovernanceAction.UPDATE_TIMELOCK_PERIOD,
+  //       payload: BigNumber.from(timelockPeriod),
+  //     });
+  //   };
+  //   azoriusContract.on(timeLockPeriodFilter, timelockPeriodListener);
+  //   return () => {
+  //     azoriusContract.off(timeLockPeriodFilter, timelockPeriodListener);
+  //   };
+  // }, [azoriusContractAddress, action, baseContracts]);
 
   return loadERC721Strategy;
 };

--- a/src/hooks/DAO/loaders/useFractalNode.ts
+++ b/src/hooks/DAO/loaders/useFractalNode.ts
@@ -8,7 +8,6 @@ import { NodeAction } from '../../../providers/App/node/action';
 import { useNetworkConfig } from '../../../providers/NetworkConfig/NetworkConfigProvider';
 import { Node } from '../../../types';
 import { mapChildNodes } from '../../../utils/hierarchy';
-import { useAsyncRetry } from '../../utils/useAsyncRetry';
 import { useLazyDAOName } from '../useDAOName';
 import { useFractalModules } from './useFractalModules';
 
@@ -33,7 +32,6 @@ export const useFractalNode = (
   const { getDaoName } = useLazyDAOName();
 
   const lookupModules = useFractalModules();
-  const { requestWithRetries } = useAsyncRetry();
 
   const formatDAOQuery = useCallback((result: { data?: DAOQueryQuery }, _daoAddress: string) => {
     if (!result.data) {

--- a/src/hooks/DAO/loaders/useFractalNode.ts
+++ b/src/hooks/DAO/loaders/useFractalNode.ts
@@ -102,11 +102,7 @@ export const useFractalNode = (
 
       try {
         if (!safeAPI) throw new Error('SafeAPI not set');
-
-        safeInfo = await requestWithRetries(
-          () => safeAPI.getSafeInfo(utils.getAddress(_daoAddress)),
-          5,
-        );
+        safeInfo = await safeAPI.getSafeInfo(utils.getAddress(_daoAddress));
       } catch (e) {
         reset({ error: true });
         return;

--- a/src/hooks/DAO/loaders/useFractalNode.ts
+++ b/src/hooks/DAO/loaders/useFractalNode.ts
@@ -125,7 +125,7 @@ export const useFractalNode = (
         payload: safeInfo,
       });
     },
-    [action, lookupModules, requestWithRetries, reset, safeAPI],
+    [action, lookupModules, reset, safeAPI],
   );
 
   useEffect(() => {

--- a/src/hooks/DAO/loaders/useProposals.ts
+++ b/src/hooks/DAO/loaders/useProposals.ts
@@ -14,17 +14,17 @@ export const useDAOProposals = () => {
   } = useFractal();
 
   const { setMethodOnInterval, clearIntervals } = useUpdateTimer(daoAddress);
-  const azoriusProposals = useAzoriusProposals();
+  const loadAzoriusProposals = useAzoriusProposals();
   const loadSafeMultisigProposals = useSafeMultisigProposals();
 
   const loadDAOProposals = useCallback(async () => {
     clearIntervals();
     if (
       (type === GovernanceType.AZORIUS_ERC20 || type === GovernanceType.AZORIUS_ERC721) &&
-      azoriusProposals !== undefined
+      loadAzoriusProposals !== undefined
     ) {
       // load Azorius proposals and strategies
-      azoriusProposals.loadAzoriusProposals(proposal => {
+      loadAzoriusProposals(proposal => {
         action.dispatch({
           type: FractalGovernanceAction.SET_AZORIUS_PROPOSAL,
           payload: proposal,
@@ -37,7 +37,7 @@ export const useDAOProposals = () => {
   }, [
     clearIntervals,
     type,
-    azoriusProposals,
+    loadAzoriusProposals,
     action,
     setMethodOnInterval,
     loadSafeMultisigProposals,

--- a/src/hooks/DAO/loaders/useProposals.ts
+++ b/src/hooks/DAO/loaders/useProposals.ts
@@ -19,10 +19,7 @@ export const useDAOProposals = () => {
 
   const loadDAOProposals = useCallback(async () => {
     clearIntervals();
-    if (
-      (type === GovernanceType.AZORIUS_ERC20 || type === GovernanceType.AZORIUS_ERC721) &&
-      loadAzoriusProposals !== undefined
-    ) {
+    if (type === GovernanceType.AZORIUS_ERC20 || type === GovernanceType.AZORIUS_ERC721) {
       // load Azorius proposals and strategies
       loadAzoriusProposals(proposal => {
         action.dispatch({

--- a/src/hooks/DAO/loaders/useProposals.ts
+++ b/src/hooks/DAO/loaders/useProposals.ts
@@ -1,5 +1,6 @@
 import { useCallback } from 'react';
 import { useFractal } from '../../../providers/App/AppProvider';
+import { FractalGovernanceAction } from '../../../providers/App/governance/action';
 import { GovernanceType } from '../../../types';
 import { useUpdateTimer } from '../../utils/useUpdateTimer';
 import { useAzoriusProposals } from './governance/useAzoriusProposals';
@@ -9,6 +10,7 @@ export const useDAOProposals = () => {
   const {
     node: { daoAddress },
     governance: { type },
+    action,
   } = useFractal();
 
   const { setMethodOnInterval, clearIntervals } = useUpdateTimer(daoAddress);
@@ -17,14 +19,29 @@ export const useDAOProposals = () => {
 
   const loadDAOProposals = useCallback(async () => {
     clearIntervals();
-    if (type === GovernanceType.AZORIUS_ERC20 || type === GovernanceType.AZORIUS_ERC721) {
+    if (
+      (type === GovernanceType.AZORIUS_ERC20 || type === GovernanceType.AZORIUS_ERC721) &&
+      loadAzoriusProposals !== undefined
+    ) {
       // load Azorius proposals and strategies
-      await loadAzoriusProposals();
+      loadAzoriusProposals(proposal => {
+        action.dispatch({
+          type: FractalGovernanceAction.SET_AZORIUS_PROPOSAL,
+          payload: proposal,
+        });
+      });
     } else if (type === GovernanceType.MULTISIG) {
       // load mulisig proposals
       setMethodOnInterval(loadSafeMultisigProposals);
     }
-  }, [type, loadAzoriusProposals, loadSafeMultisigProposals, setMethodOnInterval, clearIntervals]);
+  }, [
+    clearIntervals,
+    type,
+    loadAzoriusProposals,
+    action,
+    setMethodOnInterval,
+    loadSafeMultisigProposals,
+  ]);
 
   return loadDAOProposals;
 };

--- a/src/hooks/DAO/loaders/useProposals.ts
+++ b/src/hooks/DAO/loaders/useProposals.ts
@@ -1,8 +1,7 @@
-import { BigNumber } from 'ethers';
 import { useCallback } from 'react';
 import { useFractal } from '../../../providers/App/AppProvider';
 import { FractalGovernanceAction } from '../../../providers/App/governance/action';
-import { AzoriusProposal, GovernanceType, ProposalVotesSummary } from '../../../types';
+import { GovernanceType } from '../../../types';
 import { useUpdateTimer } from '../../utils/useUpdateTimer';
 import { useAzoriusProposals } from './governance/useAzoriusProposals';
 import { useSafeMultisigProposals } from './governance/useSafeMultisigProposals';
@@ -14,68 +13,8 @@ export const useDAOProposals = () => {
     action,
   } = useFractal();
 
-  const proposalCreatedEventCallback = useCallback(
-    (proposal: AzoriusProposal) => {
-      action.dispatch({
-        type: FractalGovernanceAction.UPDATE_PROPOSALS_NEW,
-        payload: proposal,
-      });
-    },
-    [action],
-  );
-
-  const erc20VotedEventCallback = useCallback(
-    (
-      proposalId: number,
-      voter: string,
-      support: number,
-      weight: BigNumber,
-      votesSummary: ProposalVotesSummary,
-    ) => {
-      action.dispatch({
-        type: FractalGovernanceAction.UPDATE_NEW_AZORIUS_ERC20_VOTE,
-        payload: {
-          proposalId: proposalId.toString(),
-          voter,
-          support,
-          weight,
-          votesSummary,
-        },
-      });
-    },
-    [action],
-  );
-
-  const erc721VotedEventCallback = useCallback(
-    (
-      proposalId: number,
-      voter: string,
-      voteType: number,
-      tokenAddresses: string[],
-      tokenIds: BigNumber[],
-      votesSummary: ProposalVotesSummary,
-    ) => {
-      action.dispatch({
-        type: FractalGovernanceAction.UPDATE_NEW_AZORIUS_ERC721_VOTE,
-        payload: {
-          proposalId: proposalId.toString(),
-          voter,
-          support: voteType,
-          tokenAddresses,
-          tokenIds: tokenIds.map(tokenId => tokenId.toString()),
-          votesSummary,
-        },
-      });
-    },
-    [action],
-  );
-
   const { setMethodOnInterval, clearIntervals } = useUpdateTimer(daoAddress);
-  const azoriusProposals = useAzoriusProposals(
-    proposalCreatedEventCallback,
-    erc20VotedEventCallback,
-    erc721VotedEventCallback,
-  );
+  const azoriusProposals = useAzoriusProposals();
   const loadSafeMultisigProposals = useSafeMultisigProposals();
 
   const loadDAOProposals = useCallback(async () => {

--- a/src/hooks/DAO/loaders/useProposals.ts
+++ b/src/hooks/DAO/loaders/useProposals.ts
@@ -1,7 +1,8 @@
+import { BigNumber } from 'ethers';
 import { useCallback } from 'react';
 import { useFractal } from '../../../providers/App/AppProvider';
 import { FractalGovernanceAction } from '../../../providers/App/governance/action';
-import { GovernanceType } from '../../../types';
+import { AzoriusProposal, GovernanceType, ProposalVotesSummary } from '../../../types';
 import { useUpdateTimer } from '../../utils/useUpdateTimer';
 import { useAzoriusProposals } from './governance/useAzoriusProposals';
 import { useSafeMultisigProposals } from './governance/useSafeMultisigProposals';
@@ -13,18 +14,78 @@ export const useDAOProposals = () => {
     action,
   } = useFractal();
 
+  const proposalCreatedEventCallback = useCallback(
+    (proposal: AzoriusProposal) => {
+      action.dispatch({
+        type: FractalGovernanceAction.UPDATE_PROPOSALS_NEW,
+        payload: proposal,
+      });
+    },
+    [action],
+  );
+
+  const erc20VotedEventCallback = useCallback(
+    (
+      proposalId: number,
+      voter: string,
+      support: number,
+      weight: BigNumber,
+      votesSummary: ProposalVotesSummary,
+    ) => {
+      action.dispatch({
+        type: FractalGovernanceAction.UPDATE_NEW_AZORIUS_ERC20_VOTE,
+        payload: {
+          proposalId: proposalId.toString(),
+          voter,
+          support,
+          weight,
+          votesSummary,
+        },
+      });
+    },
+    [action],
+  );
+
+  const erc721VotedEventCallback = useCallback(
+    (
+      proposalId: number,
+      voter: string,
+      voteType: number,
+      tokenAddresses: string[],
+      tokenIds: BigNumber[],
+      votesSummary: ProposalVotesSummary,
+    ) => {
+      action.dispatch({
+        type: FractalGovernanceAction.UPDATE_NEW_AZORIUS_ERC721_VOTE,
+        payload: {
+          proposalId: proposalId.toString(),
+          voter,
+          support: voteType,
+          tokenAddresses,
+          tokenIds: tokenIds.map(tokenId => tokenId.toString()),
+          votesSummary,
+        },
+      });
+    },
+    [action],
+  );
+
   const { setMethodOnInterval, clearIntervals } = useUpdateTimer(daoAddress);
-  const loadAzoriusProposals = useAzoriusProposals();
+  const azoriusProposals = useAzoriusProposals(
+    proposalCreatedEventCallback,
+    erc20VotedEventCallback,
+    erc721VotedEventCallback,
+  );
   const loadSafeMultisigProposals = useSafeMultisigProposals();
 
   const loadDAOProposals = useCallback(async () => {
     clearIntervals();
     if (
       (type === GovernanceType.AZORIUS_ERC20 || type === GovernanceType.AZORIUS_ERC721) &&
-      loadAzoriusProposals !== undefined
+      azoriusProposals !== undefined
     ) {
       // load Azorius proposals and strategies
-      loadAzoriusProposals(proposal => {
+      azoriusProposals.loadAzoriusProposals(proposal => {
         action.dispatch({
           type: FractalGovernanceAction.SET_AZORIUS_PROPOSAL,
           payload: proposal,
@@ -37,7 +98,7 @@ export const useDAOProposals = () => {
   }, [
     clearIntervals,
     type,
-    loadAzoriusProposals,
+    azoriusProposals,
     action,
     setMethodOnInterval,
     loadSafeMultisigProposals,

--- a/src/hooks/DAO/loaders/useProposals.ts
+++ b/src/hooks/DAO/loaders/useProposals.ts
@@ -1,6 +1,5 @@
 import { useCallback } from 'react';
 import { useFractal } from '../../../providers/App/AppProvider';
-import { FractalGovernanceAction } from '../../../providers/App/governance/action';
 import { GovernanceType } from '../../../types';
 import { useUpdateTimer } from '../../utils/useUpdateTimer';
 import { useAzoriusProposals } from './governance/useAzoriusProposals';
@@ -10,7 +9,6 @@ export const useDAOProposals = () => {
   const {
     node: { daoAddress },
     governance: { type },
-    action,
   } = useFractal();
 
   const { setMethodOnInterval, clearIntervals } = useUpdateTimer(daoAddress);
@@ -21,23 +19,12 @@ export const useDAOProposals = () => {
     clearIntervals();
     if (type === GovernanceType.AZORIUS_ERC20 || type === GovernanceType.AZORIUS_ERC721) {
       // load Azorius proposals and strategies
-      const proposals = await loadAzoriusProposals();
-      action.dispatch({
-        type: FractalGovernanceAction.SET_PROPOSALS,
-        payload: proposals,
-      });
+      await loadAzoriusProposals();
     } else if (type === GovernanceType.MULTISIG) {
       // load mulisig proposals
       setMethodOnInterval(loadSafeMultisigProposals);
     }
-  }, [
-    type,
-    loadAzoriusProposals,
-    action,
-    loadSafeMultisigProposals,
-    setMethodOnInterval,
-    clearIntervals,
-  ]);
+  }, [type, loadAzoriusProposals, loadSafeMultisigProposals, setMethodOnInterval, clearIntervals]);
 
   return loadDAOProposals;
 };

--- a/src/hooks/DAO/proposal/useSubmitProposal.ts
+++ b/src/hooks/DAO/proposal/useSubmitProposal.ts
@@ -313,7 +313,6 @@ export default function useSubmitProposal() {
       });
 
       setPendingCreateTx(true);
-      let success = false;
       try {
         const transactions = proposalData.targets.map((target, index) => ({
           to: target,
@@ -335,7 +334,7 @@ export default function useSubmitProposal() {
             }),
           )
         ).wait();
-        success = true;
+        console.log('success');
         toast.dismiss(toastId);
         toast(successToastMessage);
         if (successCallback) {
@@ -348,17 +347,8 @@ export default function useSubmitProposal() {
       } finally {
         setPendingCreateTx(false);
       }
-
-      if (success) {
-        const averageBlockTime = await getAverageBlockTime(provider);
-        // Frequently there's an error in loadDAOProposals if we're loading the proposal immediately after proposal creation
-        // The error occurs because block of proposal creation not yet mined and trying to fetch underlying data of voting weight for new proposal fails with that error
-        // The code that throws an error: https://github.com/decent-dao/fractal-contracts/blob/develop/contracts/azorius/LinearERC20Voting.sol#L205-L211
-        // So to avoid showing error toast - we're marking proposal creation as success and only then re-fetching proposals
-        setTimeout(loadDAOProposals, averageBlockTime * 1.5 * 1000);
-      }
     },
-    [loadDAOProposals, provider, addressPrefix],
+    [provider, addressPrefix],
   );
 
   const submitProposal = useCallback(

--- a/src/hooks/DAO/proposal/useSubmitProposal.ts
+++ b/src/hooks/DAO/proposal/useSubmitProposal.ts
@@ -334,7 +334,6 @@ export default function useSubmitProposal() {
             }),
           )
         ).wait();
-        console.log('success');
         toast.dismiss(toastId);
         toast(successToastMessage);
         if (successCallback) {

--- a/src/hooks/DAO/proposal/useSubmitProposal.ts
+++ b/src/hooks/DAO/proposal/useSubmitProposal.ts
@@ -22,7 +22,6 @@ import {
   ProposalMetadata,
 } from '../../../types';
 import { buildSafeApiUrl, getAzoriusModuleFromModules } from '../../../utils';
-import { getAverageBlockTime } from '../../../utils/contract';
 import useSafeContracts from '../../safe/useSafeContracts';
 import useSignerOrProvider from '../../utils/useSignerOrProvider';
 import { useFractalModules } from '../loaders/useFractalModules';

--- a/src/hooks/DAO/useDAOController.ts
+++ b/src/hooks/DAO/useDAOController.ts
@@ -2,6 +2,7 @@ import { utils } from 'ethers';
 import { useSearchParams } from 'react-router-dom';
 import { useFractal } from '../../providers/App/AppProvider';
 import { useNetworkConfig } from '../../providers/NetworkConfig/NetworkConfigProvider';
+import { useAzoriusProposalListeners } from './loaders/governance/useAzoriusProposalListeners';
 import { useERC20Claim } from './loaders/governance/useERC20Claim';
 import { useSnapshotProposals } from './loaders/snapshot/useSnapshotProposals';
 import { useFractalFreeze } from './loaders/useFractalFreeze';
@@ -48,6 +49,7 @@ export default function useDAOController() {
   useFractalTreasury();
   useERC20Claim();
   useSnapshotProposals();
+  useAzoriusProposalListeners();
 
   return { invalidQuery, wrongNetwork, errorLoading };
 }

--- a/src/hooks/DAO/useDAOController.ts
+++ b/src/hooks/DAO/useDAOController.ts
@@ -2,7 +2,7 @@ import { utils } from 'ethers';
 import { useSearchParams } from 'react-router-dom';
 import { useFractal } from '../../providers/App/AppProvider';
 import { useNetworkConfig } from '../../providers/NetworkConfig/NetworkConfigProvider';
-import { useAzoriusProposalListeners } from './loaders/governance/useAzoriusProposalListeners';
+import { useAzoriusListeners } from './loaders/governance/useAzoriusListeners';
 import { useERC20Claim } from './loaders/governance/useERC20Claim';
 import { useSnapshotProposals } from './loaders/snapshot/useSnapshotProposals';
 import { useFractalFreeze } from './loaders/useFractalFreeze';
@@ -49,7 +49,7 @@ export default function useDAOController() {
   useFractalTreasury();
   useERC20Claim();
   useSnapshotProposals();
-  useAzoriusProposalListeners();
+  useAzoriusListeners();
 
   return { invalidQuery, wrongNetwork, errorLoading };
 }

--- a/src/providers/App/governance/action.ts
+++ b/src/providers/App/governance/action.ts
@@ -16,6 +16,7 @@ import { ProposalTemplate } from '../../../types/createProposalTemplate';
 export enum FractalGovernanceAction {
   SET_GOVERNANCE_TYPE = 'SET_GOVERNANCE_TYPE',
   SET_PROPOSALS = 'SET_PROPOSALS',
+  SET_AZORIUS_PROPOSAL = 'SET_AZORIUS_PROPOSAL',
   SET_SNAPSHOT_PROPOSALS = 'SET_SNAPSHOT_PROPOSALS',
   SET_PROPOSAL_TEMPLATES = 'SET_PROPOSAL_TEMPLATES',
   SET_STRATEGY = 'SET_STRATEGY',
@@ -59,6 +60,10 @@ export type FractalGovernanceActions =
   | {
       type: FractalGovernanceAction.SET_PROPOSALS;
       payload: FractalProposal[];
+    }
+  | {
+      type: FractalGovernanceAction.SET_AZORIUS_PROPOSAL;
+      payload: FractalProposal;
     }
   | {
       type: FractalGovernanceAction.SET_SNAPSHOT_PROPOSALS;

--- a/src/providers/App/governance/reducer.ts
+++ b/src/providers/App/governance/reducer.ts
@@ -44,6 +44,12 @@ export const governanceReducer = (state: FractalGovernance, action: FractalGover
         ],
       };
     }
+    case FractalGovernanceAction.SET_AZORIUS_PROPOSAL: {
+      return {
+        ...state,
+        proposals: [...(proposals || []), action.payload],
+      };
+    }
     case FractalGovernanceAction.SET_PROPOSAL_TEMPLATES: {
       return { ...state, proposalTemplates: action.payload };
     }

--- a/src/providers/NetworkConfig/web3-modal.config.ts
+++ b/src/providers/NetworkConfig/web3-modal.config.ts
@@ -30,6 +30,9 @@ export const wagmiConfig = defaultWagmiConfig({
   transports: {
     [mainnet.id]: http(
       `https://eth-mainnet.g.alchemy.com/v2/${import.meta.env.VITE_APP_ALCHEMY_MAINNET_API_KEY}`,
+      {
+        batch: true,
+      },
     ),
     [sepolia.id]: http(
       `https://eth-sepolia.g.alchemy.com/v2/${import.meta.env.VITE_APP_ALCHEMY_SEPOLIA_API_KEY}`,

--- a/src/utils/azorius.ts
+++ b/src/utils/azorius.ts
@@ -27,6 +27,7 @@ import {
   DecodedTransaction,
   VotingStrategyType,
   ERC721ProposalVote,
+  MetaTransaction,
 } from '../types';
 import { Providers } from '../types/network';
 import { getTimeStamp } from './contract';
@@ -293,3 +294,13 @@ export const parseDecodedData = (
 export function getAzoriusModuleFromModules(modules: FractalModuleData[]) {
   return modules.find(module => module.moduleType === FractalModuleType.AZORIUS);
 }
+
+export const decodeTransactions = async (
+  _decode: (value: string, to: string, data?: string | undefined) => Promise<DecodedTransaction[]>,
+  _transactions: MetaTransaction[],
+) => {
+  const decodedTransactions = await Promise.all(
+    _transactions.map(async tx => _decode(tx.value.toString(), tx.to, tx.data)),
+  );
+  return decodedTransactions.flat();
+};

--- a/src/utils/azorius.ts
+++ b/src/utils/azorius.ts
@@ -48,14 +48,7 @@ const getQuorum = async (
   let quorum;
 
   if (strategyType === VotingStrategyType.LINEAR_ERC20 && erc20StrategyContract) {
-    try {
-      quorum = await erc20StrategyContract.quorumVotes(proposalId);
-    } catch (e) {
-      // For who knows reason - strategy.quorumVotes might give you an error
-      // Seems like occuring when token deployment haven't worked properly
-      logError('Error while getting strategy quorum', e);
-      quorum = BigNumber.from(0);
-    }
+    quorum = await erc20StrategyContract.quorumVotes(proposalId);
   } else if (strategyType === VotingStrategyType.LINEAR_ERC721 && erc721StrategyContract) {
     quorum = await erc721StrategyContract.quorumThreshold();
   } else {


### PR DESCRIPTION
Closes #1509 
Closes #1457 
Closes #1464

### User facing changes

- Loads Azorius proposals sequentially instead of all at once.
- No change to how Multisig or Snapshot proposals / transactions are loaded.

### Behind the scenes changes

- Moved a handful of event listeners from various places (mostly `useAzoriusProposals`, but also `useERC20LinearStrategy` and `useERC721LinearStrategy`) into their own new top-level hook, `useAzoriusListeners`
- Optimized proposal object creation logic to no longer need to fetch `Voted` events or `ProposalExecuted` events for each proposal. Instead, fetch them all just once before processing each proposal. Because they're not indexed, we have to just get all of them anyway. So just pass them down into the proposal processing and filter the same static set per proposal.
- Plenty of other stuff, but I guess mostly just a lot of refactoring.
  - Start with `useAzoriusProposals`, then check out `azorius.ts`, then check out `useAzoriusListeners`, then check out the other little things strewn around.

### Potential follow up work

- More consistent and accurate "loading" components for the proposals. Both when they start (still seeing "no proposals" message before the first one loads in), and while they're loading (would be good to have a "more proposals loading" component at the bottom that stays there until they're all done).
- Cache completed proposals in local storage, so we don't need to re-fetch them.

### Testing

- Bring up a DAO with many Azorius proposals: see how they load.
- Before they're finished loading in, switch to a new DAO (in-app, via Favorites or Hierarchy or Search): see how the first DAO's proposals _don't_ populate into this new DAO yay.
- All other user experience and behavior should be unchanged.