### PR TITLE
remove Current DAO from favorites list

### DIFF
--- a/src/hooks/DAO/loaders/useFavorites.ts
+++ b/src/hooks/DAO/loaders/useFavorites.ts
@@ -16,8 +16,12 @@ export const useAccountFavorites = () => {
   const [favoritesList, setFavoritesList] = useState<string[]>([]);
 
   useEffect(() => {
-    setFavoritesList(getValue(CacheKeys.FAVORITES));
-  }, [getValue]);
+    let favorites = getValue(CacheKeys.FAVORITES);
+    if (!!daoAddress && Array.isArray(favorites) && favorites.includes(daoAddress)) {
+      favorites = favorites.filter((favorite: string) => favorite !== daoAddress);
+    }
+    setFavoritesList(favorites);
+  }, [getValue, daoAddress]);
 
   /**
    * @returns favorited status of loaded safe


### PR DESCRIPTION
No Issue. But I'll add This PR to the project board in its stead. 

Noticed this bug earlier today, decided to go ahead and fix it.

Reproduce: (on dev)
1. Go to any DAO thats is a favorite
2. Click the same DAO you are viewing

You will see that it gets stuck in loading state.

This fixes by removing it from the list in the first place.
