### PR TITLE
Fix freeze button state bug

### DIFF
--- a/src/hooks/DAO/loaders/useFractalFreeze.ts
+++ b/src/hooks/DAO/loaders/useFractalFreeze.ts
@@ -164,15 +164,15 @@ export const useFractalFreeze = ({
       guardContracts.freezeVotingType !== null &&
       !!guardContracts.freezeVotingContractAddress &&
       loadOnMount &&
-      guardContracts.freezeVotingContractAddress + parentSafeAddress !== loadKey.current
+      guardContracts.freezeVotingContractAddress + parentSafeAddress + account !== loadKey.current
     ) {
       setFractalFreezeGuard(guardContracts);
-      loadKey.current = guardContracts.freezeVotingContractAddress + parentSafeAddress;
+      loadKey.current = guardContracts.freezeVotingContractAddress + parentSafeAddress + account;
     }
     if (!parentSafeAddress) {
       loadKey.current = undefined;
     }
-  }, [setFractalFreezeGuard, guardContracts, parentSafeAddress, loadOnMount]);
+  }, [setFractalFreezeGuard, guardContracts, parentSafeAddress, loadOnMount, account]);
 
   useEffect(() => {
     const { freezeVotingContractAddress, freezeVotingType: freezeVotingType } = guardContracts;


### PR DESCRIPTION
Closes #1508

This PR fixes a bug preventing the freeze button on a freeze proposal from updating itself when the connected wallet acount changes.

### Testing
- Make sure to be on a parent DAO with more than one signer
- On a sub-DAO (also with more than one signer), initiate a freeze
- Change account to a signer on the DAO. The button should update itself in time, after which the user can execute their vote.

### Notes
- The behaviour of a permutation of signers on the parent and child     DAOs where signers on the parent are not necessarily on the child and vice versa is untested
- The parent dao should have at least as many signers as the child dao requires to execute a proposal. If fewer, the freeze proposal can never get executed
- Even if the parent dao requires more than one signer, if the child dao requires just one, initiated freezes are immediately executed.