### PR TITLE
Fix for appending `templateHash` query parameter

### DIFF
--- a/src/components/ui/modals/ForkProposalTemplateModal.tsx
+++ b/src/components/ui/modals/ForkProposalTemplateModal.tsx
@@ -78,7 +78,7 @@ export default function ForkProposalTemplateModal({
       `${DAO_ROUTES.proposalTemplateNew.relative(
         addressPrefix,
         targetDAOAddress,
-      )}?templatesHash=${proposalTemplatesHash}&templateIndex=${templateIndex}`,
+      )}&templatesHash=${proposalTemplatesHash}&templateIndex=${templateIndex}`,
     );
     onClose();
   };


### PR DESCRIPTION
All new query params should now be appended with `&`, because the `dao` param is first with `?` already

Closes #1526