### PR TITLE
Fix DAO name doesn't update after edit

### DIFF
--- a/src/components/ui/page/Header/PageHeader.tsx
+++ b/src/components/ui/page/Header/PageHeader.tsx
@@ -11,6 +11,7 @@ import {
 } from '@chakra-ui/react';
 import { ReactNode, useEffect, useState } from 'react';
 import { DAO_ROUTES } from '../../../../constants/routes';
+import { createAccountSubstring } from '../../../../hooks/utils/useDisplayName';
 import { useFractal } from '../../../../providers/App/AppProvider';
 import { useNetworkConfig } from '../../../../providers/NetworkConfig/NetworkConfigProvider';
 import AddressCopier from '../../links/AddressCopier';
@@ -56,7 +57,7 @@ function PageHeader({
     if (hasDAOLink && daoAddress) {
       setLinks([
         {
-          terminus: daoName || '',
+          terminus: daoName || (daoAddress && createAccountSubstring(daoAddress)) || '',
           path: DAO_ROUTES.dao.relative(addressPrefix, daoAddress),
         },
         ...breadcrumbs,

--- a/src/hooks/DAO/useDAOName.ts
+++ b/src/hooks/DAO/useDAOName.ts
@@ -6,8 +6,6 @@ import { getEventRPC } from '../../helpers';
 import { useFractal } from '../../providers/App/AppProvider';
 import { useEthersProvider } from '../../providers/Ethers/hooks/useEthersProvider';
 import { useNetworkConfig } from '../../providers/NetworkConfig/NetworkConfigProvider';
-import { CacheKeys } from '../utils/cache/cacheDefaults';
-import { useLocalStorage } from '../utils/cache/useLocalStorage';
 import { createAccountSubstring } from '../utils/useDisplayName';
 
 /**
@@ -32,7 +30,6 @@ export default function useDAOName({
     address: address as Address,
     chainId,
   });
-  const { getValue } = useLocalStorage();
 
   const getDaoName = useCallback(async () => {
     if (!address || !baseContracts) {
@@ -45,11 +42,6 @@ export default function useDAOName({
       return;
     }
 
-    const cachedName = getValue(CacheKeys.DAO_NAME_PREFIX + address);
-    if (cachedName) {
-      setDAORegistryName(cachedName);
-      return;
-    }
     const { fractalRegistryContract } = baseContracts;
     if (!fractalRegistryContract) {
       setDAORegistryName(createAccountSubstring(address));
@@ -71,7 +63,7 @@ export default function useDAOName({
       const { daoName } = latestEvent.args;
       setDAORegistryName(daoName);
     }
-  }, [address, ensName, baseContracts, getValue, registryName]);
+  }, [address, ensName, baseContracts, registryName]);
 
   useEffect(() => {
     (async () => {
@@ -92,14 +84,9 @@ export default function useDAOName({
  * @dev this is used on initial load of the DAO Node, after subGraph data is loaded
  */
 export function useLazyDAOName() {
-  const { getValue } = useLocalStorage();
   const provider = useEthersProvider();
   const getDaoName = useCallback(
     async (_address: string, _registryName?: string | null): Promise<string> => {
-      const cachedName = getValue(CacheKeys.DAO_NAME_PREFIX + _address);
-      if (cachedName) {
-        return cachedName;
-      }
       if (provider) {
         // check if ens name resolves
         const ensName = await provider.lookupAddress(_address).catch(() => null);
@@ -114,7 +101,7 @@ export function useLazyDAOName() {
 
       return createAccountSubstring(_address);
     },
-    [getValue, provider],
+    [provider],
   );
 
   return { getDaoName };

--- a/src/hooks/DAO/useDAOName.ts
+++ b/src/hooks/DAO/useDAOName.ts
@@ -32,7 +32,7 @@ export default function useDAOName({
     address: address as Address,
     chainId,
   });
-  const { setValue, getValue } = useLocalStorage();
+  const { getValue } = useLocalStorage();
 
   const getDaoName = useCallback(async () => {
     if (!address || !baseContracts) {
@@ -69,10 +69,9 @@ export default function useDAOName({
       }
 
       const { daoName } = latestEvent.args;
-      setValue(CacheKeys.DAO_NAME_PREFIX + address, daoName, 60);
       setDAORegistryName(daoName);
     }
-  }, [address, ensName, baseContracts, getValue, setValue, registryName]);
+  }, [address, ensName, baseContracts, getValue, registryName]);
 
   useEffect(() => {
     (async () => {
@@ -93,7 +92,7 @@ export default function useDAOName({
  * @dev this is used on initial load of the DAO Node, after subGraph data is loaded
  */
 export function useLazyDAOName() {
-  const { setValue, getValue } = useLocalStorage();
+  const { getValue } = useLocalStorage();
   const provider = useEthersProvider();
   const getDaoName = useCallback(
     async (_address: string, _registryName?: string | null): Promise<string> => {
@@ -105,19 +104,17 @@ export function useLazyDAOName() {
         // check if ens name resolves
         const ensName = await provider.lookupAddress(_address).catch(() => null);
         if (ensName) {
-          setValue(CacheKeys.DAO_NAME_PREFIX + _address, ensName, 5);
           return ensName;
         }
       }
 
       if (_registryName) {
-        setValue(CacheKeys.DAO_NAME_PREFIX + _address, _registryName, 5);
         return _registryName;
       }
 
       return createAccountSubstring(_address);
     },
-    [getValue, setValue, provider],
+    [getValue, provider],
   );
 
   return { getDaoName };

--- a/src/hooks/utils/cache/cacheDefaults.ts
+++ b/src/hooks/utils/cache/cacheDefaults.ts
@@ -26,7 +26,6 @@ export enum CacheKeys {
   FAVORITES = 'favorites',
   AUDIT_WARNING_SHOWN = 'audit_warning_shown',
   ENS_RESOLVE_PREFIX = 'ens_resolve_', // name.eth -> 0x0 caching
-  DAO_NAME_PREFIX = 'dao_name_',
   DECODED_TRANSACTION_PREFIX = 'decode_trans_',
   MULTISIG_METADATA_PREFIX = 'm_m_',
   MASTER_COPY_PREFIX = 'master_copy_of_',


### PR DESCRIPTION
This PR removes the local storage of the DAO name. Since this data apparently exists on a subgraph, it's auto-updated (after some time).

There isn't much of a tradeoff in completely removing the DAO name cache. There was a split second where, in the breadcrumbs, the name would be empty while being fetched. I have replaced this with the DAO address substring, so it's less jarring.