### PR TITLE
Fix ProposalMetadata padding

### DIFF
--- a/src/components/ProposalBuilder/ProposalMetadata.tsx
+++ b/src/components/ProposalBuilder/ProposalMetadata.tsx
@@ -20,6 +20,7 @@ export default function ProposalMetadata({
     <VStack
       align="left"
       spacing={8}
+      p="1.5rem"
     >
       <InputComponent
         label={isProposalMode ? t('proposalTitle', { ns: 'proposal' }) : t('proposalTemplateTitle')}


### PR DESCRIPTION
Artifact from previous PR work -- metadata screen lost its padding. Fixed.

before:
<img width="931" alt="Screenshot 2024-04-30 at 12 35 56" src="https://github.com/decentdao/fractal-interface/assets/7101382/a78fc39b-6d88-4e51-b0b5-6e30e1d76b11">

after:

<img width="877" alt="Screenshot 2024-04-30 at 12 36 23" src="https://github.com/decentdao/fractal-interface/assets/7101382/da75a540-edfb-471b-992c-9807005c7759">
