### PR TITLE
Reskin/menu UI

### DIFF
--- a/src/components/Proposals/index.tsx
+++ b/src/components/Proposals/index.tsx
@@ -1,4 +1,4 @@
-import { Box, Flex, Text, Button, Icon } from '@chakra-ui/react';
+import { Box, Flex, Button, Icon } from '@chakra-ui/react';
 import { Funnel, CaretDown } from '@phosphor-icons/react';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -6,7 +6,6 @@ import useProposals from '../../hooks/DAO/proposal/useProposals';
 import { useFractal } from '../../providers/App/AppProvider';
 import { SortBy, GovernanceType, FractalProposalState } from '../../types';
 import { OptionMenu } from '../ui/menus/OptionMenu';
-import Divider from '../ui/utils/Divider';
 import { Sort } from '../ui/utils/Sort';
 import { ProposalsList } from './ProposalsList';
 
@@ -139,7 +138,10 @@ export default function Proposals() {
           showOptionCount
         >
           <Box>
-            <Flex justifyContent="space-between">
+            <Flex
+              px="0.5rem"
+              justifyContent="space-between"
+            >
               <Button
                 variant="text"
                 paddingLeft={0}
@@ -147,8 +149,14 @@ export default function Proposals() {
                 justifyContent="flex-start"
                 onClick={() => setFilters(allOptions)}
               >
-                <Text color="grayscale.100">{t('selectAll', { ns: 'common' })}</Text>
+                <Button
+                  variant="tertiary"
+                  size="sm"
+                >
+                  {t('selectAll', { ns: 'common' })}
+                </Button>
               </Button>
+              <Box width="1.5rem" />
               <Button
                 variant="text"
                 paddingLeft={0}
@@ -156,12 +164,17 @@ export default function Proposals() {
                 justifyContent="flex-end"
                 onClick={() => setFilters([])}
               >
-                <Text color="grayscale.100">{t('clear', { ns: 'common' })}</Text>
+                <Button
+                  variant="tertiary"
+                  size="sm"
+                >
+                  {t('clear', { ns: 'common' })}
+                </Button>
               </Button>
             </Flex>
-            <Divider my={4} />
           </Box>
         </OptionMenu>
+
         <Sort
           sortBy={sortBy}
           setSortBy={setSortBy}

--- a/src/components/Proposals/index.tsx
+++ b/src/components/Proposals/index.tsx
@@ -141,35 +141,23 @@ export default function Proposals() {
             <Flex
               px="0.5rem"
               justifyContent="space-between"
+              gap="1.5rem"
             >
               <Button
-                variant="text"
-                paddingLeft={0}
-                paddingRight={0}
-                justifyContent="flex-start"
+                variant="tertiary"
+                size="sm"
+                mt="0.5rem"
                 onClick={() => setFilters(allOptions)}
               >
-                <Button
-                  variant="tertiary"
-                  size="sm"
-                >
-                  {t('selectAll', { ns: 'common' })}
-                </Button>
+                {t('selectAll', { ns: 'common' })}
               </Button>
-              <Box width="1.5rem" />
               <Button
-                variant="text"
-                paddingLeft={0}
-                paddingRight={0}
-                justifyContent="flex-end"
+                variant="tertiary"
+                size="sm"
+                mt="0.5rem"
                 onClick={() => setFilters([])}
               >
-                <Button
-                  variant="tertiary"
-                  size="sm"
-                >
-                  {t('clear', { ns: 'common' })}
-                </Button>
+                {t('clear', { ns: 'common' })}
               </Button>
             </Flex>
           </Box>

--- a/src/components/ui/menus/AccountDisplay/AccountMenuButton.tsx
+++ b/src/components/ui/menus/AccountDisplay/AccountMenuButton.tsx
@@ -6,7 +6,7 @@ import useDisplayName from '../../../../hooks/utils/useDisplayName';
 import { useFractal } from '../../../../providers/App/AppProvider';
 import Avatar from '../../page/Header/Avatar';
 
-export function NotConnected() {
+function ConnectWalletButton() {
   const { t } = useTranslation('menu');
   return (
     <Flex
@@ -22,7 +22,7 @@ export function NotConnected() {
   );
 }
 
-export function Connected() {
+function WalletMenuButton() {
   const {
     readOnly: { user },
   } = useFractal();
@@ -54,12 +54,10 @@ export function Connected() {
   );
 }
 
-export function MenuButtonDisplay() {
+export function AccountMenuButton() {
   const {
     readOnly: { user },
   } = useFractal();
-  if (!user.address) {
-    return <NotConnected />;
-  }
-  return <Connected />;
+
+  return user.address ? <WalletMenuButton /> : <ConnectWalletButton />;
 }

--- a/src/components/ui/menus/AccountDisplay/ConnectedWalletMenuItem.tsx
+++ b/src/components/ui/menus/AccountDisplay/ConnectedWalletMenuItem.tsx
@@ -11,7 +11,7 @@ import Avatar from '../../page/Header/Avatar';
  * Display to show a users connected wallet information
  * Allows for copying of address
  */
-export function MenuItemWallet() {
+export function ConnectedWalletMenuItem() {
   const {
     readOnly: { user },
   } = useFractal();
@@ -29,7 +29,6 @@ export function MenuItemWallet() {
       data-testid="accountMenu-wallet"
       cursor="default"
       pt="0.5rem"
-      bg="neutral-3"
     >
       <Text
         px="0.5rem"

--- a/src/components/ui/menus/AccountDisplay/MenuItemButton.tsx
+++ b/src/components/ui/menus/AccountDisplay/MenuItemButton.tsx
@@ -16,7 +16,7 @@ export function MenuItemButton({
   onClick?: () => void;
 }) {
   return (
-    <Box bg="neutral-3">
+    <Box>
       <MenuItem
         as={Button}
         variant="tertiary"

--- a/src/components/ui/menus/AccountDisplay/NetworkSelector.tsx
+++ b/src/components/ui/menus/AccountDisplay/NetworkSelector.tsx
@@ -10,7 +10,7 @@ import {
 /**
  * Network display for menu
  */
-export function MenuItemNetwork() {
+export function NetworkSelector() {
   const { t } = useTranslation('menu');
   const { chain } = useNetworkConfig();
   const { switchChain } = useSwitchChain();
@@ -18,7 +18,6 @@ export function MenuItemNetwork() {
   return (
     <Box
       cursor="default"
-      bg="neutral-3"
       pt="0.5rem"
     >
       <Flex

--- a/src/components/ui/menus/AccountDisplay/WalletMenu.tsx
+++ b/src/components/ui/menus/AccountDisplay/WalletMenu.tsx
@@ -3,13 +3,14 @@ import { Link, Plugs } from '@phosphor-icons/react';
 import { useWeb3Modal } from '@web3modal/wagmi/react';
 import { useTranslation } from 'react-i18next';
 import { useDisconnect } from 'wagmi';
+import { NEUTRAL_2_82_TRANSPARENT } from '../../../../constants/common';
 import { useFractal } from '../../../../providers/App/AppProvider';
 import Divider from '../../utils/Divider';
+import { ConnectedWalletMenuItem } from './ConnectedWalletMenuItem';
 import { MenuItemButton } from './MenuItemButton';
-import { MenuItemNetwork } from './MenuItemNetwork';
-import { MenuItemWallet } from './MenuItemWallet';
+import { NetworkSelector } from './NetworkSelector';
 
-export function MenuItems() {
+export function WalletMenu() {
   const {
     readOnly: { user },
   } = useFractal();
@@ -21,18 +22,17 @@ export function MenuItems() {
     <MenuList
       w="16.25rem"
       rounded="0.5rem"
-      boxShadow="0px 1px 0px 0px var(--chakra-colors-neutral-1)"
-      bg="rgba(38, 33, 42, 0.74)"
+      bg={NEUTRAL_2_82_TRANSPARENT}
       border="1px solid"
       borderColor="neutral-3"
     >
       {user.address && (
         <>
-          <MenuItemWallet />
+          <ConnectedWalletMenuItem />
           <Divider />
         </>
       )}
-      <MenuItemNetwork />
+      <NetworkSelector />
       <Divider />
       {!user.address && (
         <MenuItemButton

--- a/src/components/ui/menus/AccountDisplay/index.tsx
+++ b/src/components/ui/menus/AccountDisplay/index.tsx
@@ -1,6 +1,6 @@
 import { Button, Menu, MenuButton } from '@chakra-ui/react';
-import { MenuButtonDisplay } from './MenuButtonDisplay';
-import { MenuItems } from './MenuItems';
+import { AccountMenuButton } from './AccountMenuButton';
+import { WalletMenu } from './WalletMenu';
 
 export function AccountDisplay() {
   return (
@@ -14,9 +14,10 @@ export function AccountDisplay() {
         data-testid="header-accountMenu"
         pr="1rem"
       >
-        <MenuButtonDisplay />
+        <AccountMenuButton />
       </Button>
-      <MenuItems />
+      
+      <WalletMenu />
     </Menu>
   );
 }

--- a/src/components/ui/menus/AccountDisplay/index.tsx
+++ b/src/components/ui/menus/AccountDisplay/index.tsx
@@ -16,7 +16,7 @@ export function AccountDisplay() {
       >
         <AccountMenuButton />
       </Button>
-      
+
       <WalletMenu />
     </Menu>
   );

--- a/src/components/ui/menus/FavoritesMenu/Favorite.tsx
+++ b/src/components/ui/menus/FavoritesMenu/Favorite.tsx
@@ -1,5 +1,6 @@
-import { Box, Button, MenuItem } from '@chakra-ui/react';
+import { Box, Button, MenuItem, Text } from '@chakra-ui/react';
 import { Star } from '@phosphor-icons/react';
+import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import { DAO_ROUTES } from '../../../../constants/routes';
 import useDAOName from '../../../../hooks/DAO/useDAOName';
@@ -13,6 +14,8 @@ export function Favorite({ network, address }: IFavorite) {
   const { daoRegistryName } = useDAOName({ address });
   const { action } = useFractal();
   const navigate = useNavigate();
+
+  const { t } = useTranslation('dashboard');
 
   const onClickNav = () => {
     action.resetDAO();
@@ -34,13 +37,14 @@ export function Favorite({ network, address }: IFavorite) {
         justifyContent="flex-start"
         gap={2}
       >
-        {daoRegistryName && (
-          <Star
-            size="1.5rem"
-            weight="fill"
-          />
-        )}
-        {daoRegistryName}
+        <Star
+          size="1.5rem"
+          weight="fill"
+        />
+
+        <Text color={daoRegistryName ? 'white-0' : 'neutral-6'}>
+          {daoRegistryName ? daoRegistryName : t('loadingFavorite')}
+        </Text>
       </MenuItem>
     </Box>
   );

--- a/src/components/ui/menus/FavoritesMenu/Favorite.tsx
+++ b/src/components/ui/menus/FavoritesMenu/Favorite.tsx
@@ -20,7 +20,7 @@ export function Favorite({ network, address }: IFavorite) {
   };
 
   return (
-    <Box bg="neutral-3">
+    <Box>
       <MenuItem
         as={Button}
         variant="tertiary"

--- a/src/components/ui/menus/FavoritesMenu/Favorite.tsx
+++ b/src/components/ui/menus/FavoritesMenu/Favorite.tsx
@@ -34,10 +34,12 @@ export function Favorite({ network, address }: IFavorite) {
         justifyContent="flex-start"
         gap={2}
       >
-        {daoRegistryName && <Star
-          size="1.5rem"
-          weight="fill"
-        />}
+        {daoRegistryName && (
+          <Star
+            size="1.5rem"
+            weight="fill"
+          />
+        )}
         {daoRegistryName}
       </MenuItem>
     </Box>

--- a/src/components/ui/menus/FavoritesMenu/Favorite.tsx
+++ b/src/components/ui/menus/FavoritesMenu/Favorite.tsx
@@ -34,10 +34,10 @@ export function Favorite({ network, address }: IFavorite) {
         justifyContent="flex-start"
         gap={2}
       >
-        <Star
+        {daoRegistryName && <Star
           size="1.5rem"
           weight="fill"
-        />
+        />}
         {daoRegistryName}
       </MenuItem>
     </Box>

--- a/src/components/ui/menus/FavoritesMenu/FavoritesList.tsx
+++ b/src/components/ui/menus/FavoritesMenu/FavoritesList.tsx
@@ -1,5 +1,6 @@
 import { Box, MenuList } from '@chakra-ui/react';
 import { useTranslation } from 'react-i18next';
+import { NEUTRAL_2_82_TRANSPARENT } from '../../../../constants/common';
 import { useAccountFavorites } from '../../../../hooks/DAO/loaders/useFavorites';
 import { useNetworkConfig } from '../../../../providers/NetworkConfig/NetworkConfigProvider';
 import { Favorite } from './Favorite';
@@ -12,8 +13,7 @@ export function FavoritesList() {
   return (
     <MenuList
       rounded="0.5rem"
-      boxShadow="0px 1px 0px 0px var(--chakra-colors-neutral-1)"
-      bg="rgba(38, 33, 42, 0.74)"
+      bg={NEUTRAL_2_82_TRANSPARENT}
       border="1px solid"
       borderColor="neutral-3"
     >
@@ -26,7 +26,6 @@ export function FavoritesList() {
             overflowY="scroll"
             sx={{
               '&::-webkit-scrollbar': {
-                background: 'neutral-3',
                 width: '0.5rem',
                 height: '0.5rem',
               },

--- a/src/components/ui/menus/FavoritesMenu/FavoritesList.tsx
+++ b/src/components/ui/menus/FavoritesMenu/FavoritesList.tsx
@@ -1,6 +1,5 @@
 import { Box, MenuList } from '@chakra-ui/react';
 import { useTranslation } from 'react-i18next';
-import { NEUTRAL_2_82_TRANSPARENT } from '../../../../constants/common';
 import { useAccountFavorites } from '../../../../hooks/DAO/loaders/useFavorites';
 import { useNetworkConfig } from '../../../../providers/NetworkConfig/NetworkConfigProvider';
 import { Favorite } from './Favorite';
@@ -13,7 +12,7 @@ export function FavoritesList() {
   return (
     <MenuList
       rounded="0.5rem"
-      bg={NEUTRAL_2_82_TRANSPARENT}
+      bg="neutral-2"
       border="1px solid"
       borderColor="neutral-3"
     >

--- a/src/components/ui/menus/OptionMenu/OptionsList.tsx
+++ b/src/components/ui/menus/OptionMenu/OptionsList.tsx
@@ -22,6 +22,7 @@ export function OptionsList({
     <>
       {titleKey && (
         <Text
+          mt="0.5rem"
           px="0.5rem"
           marginBottom="0.5rem"
           textStyle="helper-text-small"

--- a/src/components/ui/menus/OptionMenu/OptionsList.tsx
+++ b/src/components/ui/menus/OptionMenu/OptionsList.tsx
@@ -22,6 +22,7 @@ export function OptionsList({
     <>
       {titleKey && (
         <Text
+          px="0.5rem"
           marginBottom="0.5rem"
           textStyle="helper-text-small"
           color="neutral-7"
@@ -38,7 +39,8 @@ export function OptionsList({
               onClick={clickListener}
               cursor="pointer"
               _hover={{ bg: 'neutral-3', textDecoration: 'none' }}
-              p="0.5rem 1rem"
+              p="0.75rem 0.5rem"
+              borderRadius="0.75rem"
               gap={2}
               closeOnSelect={closeOnSelect}
               data-testid={'optionMenu-' + option.optionKey}
@@ -57,12 +59,7 @@ export function OptionsList({
               )}
               {showOptionCount && <Text as="span">{option.count}</Text>}
             </MenuItem>
-            {options[options.length - 1] !== option && (
-              <Divider
-                marginTop="0.25rem"
-                marginBottom="0.25rem"
-              />
-            )}
+            {options[options.length - 1] !== option && <Divider />}
           </Box>
         );
       })}

--- a/src/components/ui/menus/OptionMenu/index.tsx
+++ b/src/components/ui/menus/OptionMenu/index.tsx
@@ -1,6 +1,7 @@
 import { Menu, MenuButton, MenuList, As, MenuProps, Tooltip } from '@chakra-ui/react';
 import { MouseEvent, ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
+import { NEUTRAL_2_82_TRANSPARENT } from '../../../../constants/common';
 import { OptionsList } from './OptionsList';
 import { IOption, IOptionsList } from './types';
 
@@ -53,9 +54,10 @@ export function OptionMenu({
       <MenuList
         borderWidth="1px"
         borderColor="neutral-3"
-        borderRadius="0.5rem"
-        bg="neutral-2" // neutral-2-84 ??
-        p="0.5rem 1rem"
+        borderRadius="0.75rem"
+        bg={NEUTRAL_2_82_TRANSPARENT}
+        backdropFilter="auto"
+        backdropBlur="10px"
         mr={['auto', '1rem']}
         zIndex={1000}
       >

--- a/src/components/ui/page/Header/index.tsx
+++ b/src/components/ui/page/Header/index.tsx
@@ -13,7 +13,7 @@ import { DecentLogo } from '@decent-org/fractal-ui';
 import { useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
-import { HEADER_HEIGHT } from '../../../../constants/common';
+import { HEADER_HEIGHT, NEUTRAL_2_82_TRANSPARENT } from '../../../../constants/common';
 import { BASE_ROUTES } from '../../../../constants/routes';
 import { useFractal } from '../../../../providers/App/AppProvider';
 import { AccountDisplay } from '../../menus/AccountDisplay';
@@ -65,7 +65,7 @@ function HeaderLogo() {
             isFullHeight
           >
             <DrawerContent
-              bg="#221D25D6" // TODO get this into `decent-ui` repo
+              bg={NEUTRAL_2_82_TRANSPARENT}
               border="none"
               backdropFilter="auto"
               backdropBlur="10px"

--- a/src/components/ui/utils/Sort.tsx
+++ b/src/components/ui/utils/Sort.tsx
@@ -71,8 +71,8 @@ export function Sort({ sortBy, setSortBy, buttonProps }: ISort) {
         borderColor="neutral-3"
         borderRadius="0.5rem"
         bg={NEUTRAL_2_82_TRANSPARENT}
-              backdropFilter="auto"
-              backdropBlur="10px"
+        backdropFilter="auto"
+        backdropBlur="10px"
         minWidth="min-content"
         zIndex={5}
       >

--- a/src/components/ui/utils/Sort.tsx
+++ b/src/components/ui/utils/Sort.tsx
@@ -1,8 +1,10 @@
-import { Divider, Flex, Icon, Menu, MenuButton, MenuItem, MenuList, Text } from '@chakra-ui/react';
+import { Flex, Icon, Menu, MenuButton, MenuItem, MenuList, Text } from '@chakra-ui/react';
 import { CaretDown } from '@phosphor-icons/react';
 import { Dispatch, SetStateAction } from 'react';
 import { useTranslation } from 'react-i18next';
+import { NEUTRAL_2_82_TRANSPARENT } from '../../../constants/common';
 import { SortBy } from '../../../types';
+import Divider from './Divider';
 
 function SortMenuItem({
   labelKey,
@@ -16,7 +18,8 @@ function SortMenuItem({
   const { t } = useTranslation();
   return (
     <MenuItem
-      py="0.5rem"
+      borderRadius="0.5rem"
+      p="0.75rem 0.5rem"
       sx={{
         '&:hover': { bg: 'neutral-3' },
       }}
@@ -67,18 +70,27 @@ export function Sort({ sortBy, setSortBy, buttonProps }: ISort) {
         borderWidth="1px"
         borderColor="neutral-3"
         borderRadius="0.5rem"
-        bg="neutral-2" // neutral-2-84 ??
-        p="0.5rem 1rem"
+        bg={NEUTRAL_2_82_TRANSPARENT}
+              backdropFilter="auto"
+              backdropBlur="10px"
         minWidth="min-content"
         zIndex={5}
       >
+        <Text
+          px="0.5rem"
+          mt={2}
+          textStyle="helper-text-small"
+          color="neutral-7"
+        >
+          {t('sortTitle')}
+        </Text>
         <SortMenuItem
           labelKey={SortBy.Newest}
           testId="sort-newest"
           onClick={() => setSortBy(SortBy.Newest)}
         />
         {/* TODO Divider look doesn't quite match */}
-        <Divider color="neutral-3" />
+        <Divider />
         <SortMenuItem
           labelKey={SortBy.Oldest}
           testId="sort-oldest"

--- a/src/components/ui/utils/Sort.tsx
+++ b/src/components/ui/utils/Sort.tsx
@@ -89,7 +89,6 @@ export function Sort({ sortBy, setSortBy, buttonProps }: ISort) {
           testId="sort-newest"
           onClick={() => setSortBy(SortBy.Newest)}
         />
-        {/* TODO Divider look doesn't quite match */}
         <Divider />
         <SortMenuItem
           labelKey={SortBy.Oldest}

--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -1,6 +1,10 @@
 export const HEADER_HEIGHT = '4.5rem';
 export const CONTENT_HEIGHT = `calc(100vh - ${HEADER_HEIGHT})`;
+
+// TODO get these into `decent-ui` repo
 export const BACKGROUND_SEMI_TRANSPARENT = '#10041480';
+export const NEUTRAL_2_82_TRANSPARENT = '#221D25D6';
+
 /**
  * Max width for most informational Tooltips. However we don't add max width
  * to some Tooltips that shouldn't wrap no matter how long, such as token amounts.

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -71,6 +71,7 @@
   "labelYearsLeft_one": "{{count}} year left",
   "labelYearsLeft_other": "{{count}} years left",
   "toastClipboardCopy": "Copied to clipboard",
+  "sortTitle": "Sort",
   "newest": "Newest",
   "oldest": "Oldest",
   "filter": "Filter",

--- a/src/i18n/locales/en/dashboard.json
+++ b/src/i18n/locales/en/dashboard.json
@@ -1,6 +1,7 @@
 {
   "titleFavorites": "Favorites",
   "emptyFavorites": "No favorites",
+  "loadingFavorite": "Loading favorite ...",
   "errorInvalidSearch": "This is not a valid Ethereum address",
   "errorFailedSearch": "Sorry, this address is not a Decent DAO or Safe on {{chain}}",
   "searchDAOPlaceholder": "Search for a Safe by address or ENS",


### PR DESCRIPTION
This PR fixes a few minor UI inconsistencies on some menus around the app. Screenshots below.

First, the sort menu is more consistent with other menus from figma:
<img width="341" alt="Screenshot 2024-05-01 at 18 23 05" src="https://github.com/decentdao/fractal-interface/assets/7101382/d3db1f66-f945-44b4-b7aa-51c58e1f0ff0">

Manage safe menu:
<img width="497" alt="Screenshot 2024-05-01 at 18 33 17" src="https://github.com/decentdao/fractal-interface/assets/7101382/bf8b7561-f6d7-48e9-b4e1-6c6ce10488d7">

Proposal filter menu
<img width="328" alt="Screenshot 2024-05-01 at 18 35 00" src="https://github.com/decentdao/fractal-interface/assets/7101382/9ec2dd99-a26d-4029-81ec-2536f0a9e45f">

Wallet menu (removed some corner artifacts):
<img width="308" alt="Screenshot 2024-05-01 at 18 37 08" src="https://github.com/decentdao/fractal-interface/assets/7101382/806cb349-e141-4caf-9d4e-dfea101ae408">
