### PR TITLE
Remove old stuff

### DIFF
--- a/src/helpers/crypto.ts
+++ b/src/helpers/crypto.ts
@@ -1,7 +1,6 @@
 import { TypedDataSigner } from '@ethersproject/abstract-signer';
 import { Contract, utils, Signer } from 'ethers';
 import { zeroAddress } from 'viem';
-import { sepolia, mainnet } from 'wagmi/chains';
 import { ContractConnection } from '../types';
 import { MetaTransaction, SafePostTransaction, SafeTransaction } from '../types/transaction';
 
@@ -188,8 +187,4 @@ export const encodeMultiSend = (txs: MetaTransaction[]): string => {
  */
 export function getEventRPC<T>(connection: ContractConnection<T>): T {
   return connection.asProvider;
-}
-
-export function supportsENS(chainId: number): boolean {
-  return chainId === sepolia.id || chainId == mainnet.id || chainId == sepolia.id;
 }

--- a/src/hooks/utils/cache/cacheDefaults.ts
+++ b/src/hooks/utils/cache/cacheDefaults.ts
@@ -24,7 +24,6 @@ export enum CacheExpiry {
  */
 export enum CacheKeys {
   FAVORITES = 'favorites',
-  AUDIT_WARNING_SHOWN = 'audit_warning_shown',
   ENS_RESOLVE_PREFIX = 'ens_resolve_', // name.eth -> 0x0 caching
   DECODED_TRANSACTION_PREFIX = 'decode_trans_',
   MULTISIG_METADATA_PREFIX = 'm_m_',
@@ -42,7 +41,6 @@ interface IndexedObject {
  */
 export const CACHE_DEFAULTS: IndexedObject = {
   [CacheKeys.FAVORITES.toString()]: Array<string>(),
-  [CacheKeys.AUDIT_WARNING_SHOWN.toString()]: true,
 };
 
 /**

--- a/src/hooks/utils/cache/cacheDefaults.ts
+++ b/src/hooks/utils/cache/cacheDefaults.ts
@@ -24,7 +24,6 @@ export enum CacheExpiry {
  */
 export enum CacheKeys {
   FAVORITES = 'favorites',
-  ENS_RESOLVE_PREFIX = 'ens_resolve_', // name.eth -> 0x0 caching
   DECODED_TRANSACTION_PREFIX = 'decode_trans_',
   MULTISIG_METADATA_PREFIX = 'm_m_',
   MASTER_COPY_PREFIX = 'master_copy_of_',

--- a/src/hooks/utils/useAddress.ts
+++ b/src/hooks/utils/useAddress.ts
@@ -1,6 +1,5 @@
 import { useEffect, useState } from 'react';
 import { getAddress, isAddress } from 'viem';
-import { supportsENS } from '../../helpers';
 import { useEthersProvider } from '../../providers/Ethers/hooks/useEthersProvider';
 import { useNetworkConfig } from '../../providers/NetworkConfig/NetworkConfigProvider';
 import { couldBeENS } from '../../utils/url';
@@ -39,11 +38,6 @@ const useAddress = (addressInput: string | undefined) => {
       setAddress(getAddress(addressInput));
       setIsValidAddress(true);
       setIsAddressLoading(false);
-      return;
-    }
-
-    // only continue with ENS checks if the chain actually supports ENS
-    if (!supportsENS(chain.id)) {
       return;
     }
 

--- a/src/types/daoProposal.ts
+++ b/src/types/daoProposal.ts
@@ -33,10 +33,6 @@ export interface AzoriusProposal extends GovernanceActivity {
   startBlock: bigint;
 }
 
-export interface AzoriusERC721Proposal extends AzoriusProposal {
-  votes: ERC721ProposalVote[];
-}
-
 export interface MultisigProposal extends GovernanceActivity {
   confirmations: SafeMultisigConfirmationResponse[];
   signersThreshold?: number;


### PR DESCRIPTION
Closes #1631 

- Remove an unused type.
- Remove an unused cache key.
- Remove a function which returns if a given network supports ENS or not.
- Remove ENS name resolution caching.

See my review comments for more context.