### PR TITLE
Add proper typing to `mapChildNodes` function

### DIFF
--- a/src/hooks/DAO/loaders/useFractalNode.ts
+++ b/src/hooks/DAO/loaders/useFractalNode.ts
@@ -40,12 +40,12 @@ export const useFractalNode = (
     const { daos } = result.data;
     const dao = daos[0];
     if (dao) {
-      const { parentAddress, name, hierarchy, snapshotENS, proposalTemplatesHash } = dao;
+      const { parentAddress, name, snapshotENS, proposalTemplatesHash } = dao;
 
       const currentNode: Node = {
         nodeHierarchy: {
           parentAddress: parentAddress as string,
-          childNodes: mapChildNodes(hierarchy),
+          childNodes: mapChildNodes(dao),
         },
         daoName: name as string,
         daoAddress: getAddress(_daoAddress as string),

--- a/src/hooks/DAO/loaders/useLoadDAONode.ts
+++ b/src/hooks/DAO/loaders/useLoadDAONode.ts
@@ -30,12 +30,12 @@ export const useLoadDAONode = () => {
     const { daos } = result.data;
     const dao = daos[0];
     if (dao) {
-      const { parentAddress, name, hierarchy, snapshotENS } = dao;
+      const { parentAddress, name, snapshotENS } = dao;
 
       const currentNode: Node = {
         nodeHierarchy: {
           parentAddress: parentAddress as string,
-          childNodes: mapChildNodes(hierarchy),
+          childNodes: mapChildNodes(dao),
         },
         daoName: name as string,
         daoAddress: getAddress(_daoAddress as string),

--- a/src/utils/hierarchy.ts
+++ b/src/utils/hierarchy.ts
@@ -1,11 +1,25 @@
-export const mapChildNodes = (_hierarchy: any) => {
-  return _hierarchy.map((node: any) => {
+import { DAO } from '../../.graphclient';
+import { Node } from '../types';
+
+type DAOQueryNode = Pick<
+  DAO,
+  | 'id'
+  | 'address'
+  | 'parentAddress'
+  | 'name'
+  | 'snapshotENS'
+  | 'proposalTemplatesHash'
+  | 'hierarchy'
+>;
+
+export const mapChildNodes = (dao: DAOQueryNode) => {
+  return dao.hierarchy.map((node: DAO): Node => {
     return {
       nodeHierarchy: {
         parentAddress: node.parentAddress,
-        childNodes: mapChildNodes(node.hierarchy),
+        childNodes: mapChildNodes(node),
       },
-      daoName: node.name,
+      daoName: node.name === null || node.name === undefined ? null : node.name,
       daoAddress: node.address,
     };
   });


### PR DESCRIPTION
Closes #1632 

The `mapChildNodes` function was typed with lots of `any`s, which I didn't like. Here is a fix for that.

Have tested loading up DAOs with and without children. Things work as expected.