### PR TITLE
Update VotesERC20

### DIFF
--- a/src/assets/abi/IVotes.ts
+++ b/src/assets/abi/IVotes.ts
@@ -1,0 +1,186 @@
+const IVotesAbi = [
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'delegator',
+        type: 'address',
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'fromDelegate',
+        type: 'address',
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'toDelegate',
+        type: 'address',
+      },
+    ],
+    name: 'DelegateChanged',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'delegate',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'previousBalance',
+        type: 'uint256',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'newBalance',
+        type: 'uint256',
+      },
+    ],
+    name: 'DelegateVotesChanged',
+    type: 'event',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'delegatee',
+        type: 'address',
+      },
+    ],
+    name: 'delegate',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'delegatee',
+        type: 'address',
+      },
+      {
+        internalType: 'uint256',
+        name: 'nonce',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256',
+        name: 'expiry',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint8',
+        name: 'v',
+        type: 'uint8',
+      },
+      {
+        internalType: 'bytes32',
+        name: 'r',
+        type: 'bytes32',
+      },
+      {
+        internalType: 'bytes32',
+        name: 's',
+        type: 'bytes32',
+      },
+    ],
+    name: 'delegateBySig',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'account',
+        type: 'address',
+      },
+    ],
+    name: 'delegates',
+    outputs: [
+      {
+        internalType: 'address',
+        name: '',
+        type: 'address',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'uint256',
+        name: 'blockNumber',
+        type: 'uint256',
+      },
+    ],
+    name: 'getPastTotalSupply',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'account',
+        type: 'address',
+      },
+      {
+        internalType: 'uint256',
+        name: 'blockNumber',
+        type: 'uint256',
+      },
+    ],
+    name: 'getPastVotes',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'account',
+        type: 'address',
+      },
+    ],
+    name: 'getVotes',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+] as const;
+
+export default IVotesAbi;

--- a/src/assets/abi/VotesERC20.ts
+++ b/src/assets/abi/VotesERC20.ts
@@ -1,0 +1,757 @@
+const VotesERC20Abi = [
+  {
+    inputs: [],
+    stateMutability: 'nonpayable',
+    type: 'constructor',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'owner',
+        type: 'address',
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'spender',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'value',
+        type: 'uint256',
+      },
+    ],
+    name: 'Approval',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'delegator',
+        type: 'address',
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'fromDelegate',
+        type: 'address',
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'toDelegate',
+        type: 'address',
+      },
+    ],
+    name: 'DelegateChanged',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'delegate',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'previousBalance',
+        type: 'uint256',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'newBalance',
+        type: 'uint256',
+      },
+    ],
+    name: 'DelegateVotesChanged',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        internalType: 'uint8',
+        name: 'version',
+        type: 'uint8',
+      },
+    ],
+    name: 'Initialized',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'previousOwner',
+        type: 'address',
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'newOwner',
+        type: 'address',
+      },
+    ],
+    name: 'OwnershipTransferred',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'id',
+        type: 'uint256',
+      },
+    ],
+    name: 'Snapshot',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'from',
+        type: 'address',
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'to',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'value',
+        type: 'uint256',
+      },
+    ],
+    name: 'Transfer',
+    type: 'event',
+  },
+  {
+    inputs: [],
+    name: 'DOMAIN_SEPARATOR',
+    outputs: [
+      {
+        internalType: 'bytes32',
+        name: '',
+        type: 'bytes32',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'owner',
+        type: 'address',
+      },
+      {
+        internalType: 'address',
+        name: 'spender',
+        type: 'address',
+      },
+    ],
+    name: 'allowance',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'spender',
+        type: 'address',
+      },
+      {
+        internalType: 'uint256',
+        name: 'amount',
+        type: 'uint256',
+      },
+    ],
+    name: 'approve',
+    outputs: [
+      {
+        internalType: 'bool',
+        name: '',
+        type: 'bool',
+      },
+    ],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'account',
+        type: 'address',
+      },
+    ],
+    name: 'balanceOf',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'account',
+        type: 'address',
+      },
+      {
+        internalType: 'uint256',
+        name: 'snapshotId',
+        type: 'uint256',
+      },
+    ],
+    name: 'balanceOfAt',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'captureSnapShot',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: 'snapId',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'account',
+        type: 'address',
+      },
+      {
+        internalType: 'uint32',
+        name: 'pos',
+        type: 'uint32',
+      },
+    ],
+    name: 'checkpoints',
+    outputs: [
+      {
+        components: [
+          {
+            internalType: 'uint32',
+            name: 'fromBlock',
+            type: 'uint32',
+          },
+          {
+            internalType: 'uint224',
+            name: 'votes',
+            type: 'uint224',
+          },
+        ],
+        internalType: 'struct ERC20VotesUpgradeable.Checkpoint',
+        name: '',
+        type: 'tuple',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'decimals',
+    outputs: [
+      {
+        internalType: 'uint8',
+        name: '',
+        type: 'uint8',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'spender',
+        type: 'address',
+      },
+      {
+        internalType: 'uint256',
+        name: 'subtractedValue',
+        type: 'uint256',
+      },
+    ],
+    name: 'decreaseAllowance',
+    outputs: [
+      {
+        internalType: 'bool',
+        name: '',
+        type: 'bool',
+      },
+    ],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'delegatee',
+        type: 'address',
+      },
+    ],
+    name: 'delegate',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'delegatee',
+        type: 'address',
+      },
+      {
+        internalType: 'uint256',
+        name: 'nonce',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256',
+        name: 'expiry',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint8',
+        name: 'v',
+        type: 'uint8',
+      },
+      {
+        internalType: 'bytes32',
+        name: 'r',
+        type: 'bytes32',
+      },
+      {
+        internalType: 'bytes32',
+        name: 's',
+        type: 'bytes32',
+      },
+    ],
+    name: 'delegateBySig',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'account',
+        type: 'address',
+      },
+    ],
+    name: 'delegates',
+    outputs: [
+      {
+        internalType: 'address',
+        name: '',
+        type: 'address',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'uint256',
+        name: 'blockNumber',
+        type: 'uint256',
+      },
+    ],
+    name: 'getPastTotalSupply',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'account',
+        type: 'address',
+      },
+      {
+        internalType: 'uint256',
+        name: 'blockNumber',
+        type: 'uint256',
+      },
+    ],
+    name: 'getPastVotes',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'account',
+        type: 'address',
+      },
+    ],
+    name: 'getVotes',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'spender',
+        type: 'address',
+      },
+      {
+        internalType: 'uint256',
+        name: 'addedValue',
+        type: 'uint256',
+      },
+    ],
+    name: 'increaseAllowance',
+    outputs: [
+      {
+        internalType: 'bool',
+        name: '',
+        type: 'bool',
+      },
+    ],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'name',
+    outputs: [
+      {
+        internalType: 'string',
+        name: '',
+        type: 'string',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'owner',
+        type: 'address',
+      },
+    ],
+    name: 'nonces',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'account',
+        type: 'address',
+      },
+    ],
+    name: 'numCheckpoints',
+    outputs: [
+      {
+        internalType: 'uint32',
+        name: '',
+        type: 'uint32',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'owner',
+    outputs: [
+      {
+        internalType: 'address',
+        name: '',
+        type: 'address',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'owner',
+        type: 'address',
+      },
+      {
+        internalType: 'address',
+        name: 'spender',
+        type: 'address',
+      },
+      {
+        internalType: 'uint256',
+        name: 'value',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256',
+        name: 'deadline',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint8',
+        name: 'v',
+        type: 'uint8',
+      },
+      {
+        internalType: 'bytes32',
+        name: 'r',
+        type: 'bytes32',
+      },
+      {
+        internalType: 'bytes32',
+        name: 's',
+        type: 'bytes32',
+      },
+    ],
+    name: 'permit',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'renounceOwnership',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'bytes',
+        name: 'initializeParams',
+        type: 'bytes',
+      },
+    ],
+    name: 'setUp',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'bytes4',
+        name: 'interfaceId',
+        type: 'bytes4',
+      },
+    ],
+    name: 'supportsInterface',
+    outputs: [
+      {
+        internalType: 'bool',
+        name: '',
+        type: 'bool',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'symbol',
+    outputs: [
+      {
+        internalType: 'string',
+        name: '',
+        type: 'string',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'totalSupply',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'uint256',
+        name: 'snapshotId',
+        type: 'uint256',
+      },
+    ],
+    name: 'totalSupplyAt',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'to',
+        type: 'address',
+      },
+      {
+        internalType: 'uint256',
+        name: 'amount',
+        type: 'uint256',
+      },
+    ],
+    name: 'transfer',
+    outputs: [
+      {
+        internalType: 'bool',
+        name: '',
+        type: 'bool',
+      },
+    ],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'from',
+        type: 'address',
+      },
+      {
+        internalType: 'address',
+        name: 'to',
+        type: 'address',
+      },
+      {
+        internalType: 'uint256',
+        name: 'amount',
+        type: 'uint256',
+      },
+    ],
+    name: 'transferFrom',
+    outputs: [
+      {
+        internalType: 'bool',
+        name: '',
+        type: 'bool',
+      },
+    ],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'newOwner',
+        type: 'address',
+      },
+    ],
+    name: 'transferOwnership',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+] as const;
+
+export default VotesERC20Abi;

--- a/src/components/DaoCreator/hooks/usePrepareFormData.ts
+++ b/src/components/DaoCreator/hooks/usePrepareFormData.ts
@@ -1,6 +1,7 @@
-import { IVotes__factory } from '@fractal-framework/fractal-contracts';
 import { useCallback } from 'react';
-import { getAddress } from 'viem';
+import { getAddress, getContract } from 'viem';
+import { usePublicClient } from 'wagmi';
+import IVotesAbi from '../../../assets/abi/IVotes';
 import { useEthersProvider } from '../../../providers/Ethers/hooks/useEthersProvider';
 import { useEthersSigner } from '../../../providers/Ethers/hooks/useEthersSigner';
 import {
@@ -19,6 +20,8 @@ type FreezeGuardConfigParam = { freezeGuard?: DAOFreezeGuardConfig<BigIntValuePa
 export function usePrepareFormData() {
   const signer = useEthersSigner();
   const provider = useEthersProvider();
+
+  const publicClient = usePublicClient();
 
   // Helper function to prepare freezeGuard data
   const prepareFreezeGuardData = useCallback(
@@ -52,18 +55,24 @@ export function usePrepareFormData() {
 
   const checkVotesToken = useCallback(
     async (address: string) => {
-      if (provider) {
+      if (publicClient) {
         try {
-          const votesContract = IVotes__factory.connect(address, provider);
-          await votesContract.delegates('0x0000000000000000000000000000000000000001');
-          await votesContract.getVotes('0x0000000000000000000000000000000000000001');
+          const votesContract = getContract({
+            abi: IVotesAbi,
+            address: getAddress(address),
+            client: publicClient,
+          });
+          await Promise.all([
+            votesContract.read.delegates(['0x0000000000000000000000000000000000000001']),
+            votesContract.read.getVotes(['0x0000000000000000000000000000000000000001']),
+          ]);
           return true;
         } catch (error) {
           return false;
         }
       }
     },
-    [provider],
+    [publicClient],
   );
 
   const prepareMultisigFormData = useCallback(

--- a/src/components/Proposals/ProposalSummary.tsx
+++ b/src/components/Proposals/ProposalSummary.tsx
@@ -4,8 +4,10 @@ import { format } from 'date-fns';
 import { formatInTimeZone } from 'date-fns-tz';
 import { useMemo, useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
+import { getAddress, getContract } from 'viem';
+import { usePublicClient } from 'wagmi';
+import VotesERC20Abi from '../../assets/abi/VotesERC20';
 import { BACKGROUND_SEMI_TRANSPARENT } from '../../constants/common';
-import useSafeContracts from '../../hooks/safe/useSafeContracts';
 import useBlockTimestamp from '../../hooks/utils/useBlockTimestamp';
 import { useFractal } from '../../providers/App/AppProvider';
 import { AzoriusGovernance, AzoriusProposal, GovernanceType } from '../../types';
@@ -36,7 +38,7 @@ export default function ProposalSummary({
       user: { votingWeight, address },
     },
   } = useFractal();
-  const baseContracts = useSafeContracts();
+
   const azoriusGovernance = governance as AzoriusGovernance;
   const { votesToken, type, erc721Tokens, votingStrategy } = azoriusGovernance;
   const { t } = useTranslation(['proposal', 'common', 'navigation']);
@@ -59,13 +61,21 @@ export default function ProposalSummary({
 
   const toggleShowVotingPower = () => setShowVotingPower(prevState => !prevState);
 
+  const publicClient = usePublicClient();
+
   useEffect(() => {
     async function loadProposalVotingWeight() {
-      if (address && baseContracts && votesToken) {
-        const tokenContract = baseContracts.votesTokenMasterCopyContract.asProvider.attach(
-          votesToken.address,
-        );
-        const pastVotingWeight = (await tokenContract.getPastVotes(address, startBlock)).toBigInt();
+      if (address && votesToken && publicClient) {
+        const tokenContract = getContract({
+          abi: VotesERC20Abi,
+          address: votesToken.address,
+          client: publicClient,
+        });
+
+        const pastVotingWeight = await tokenContract.read.getPastVotes([
+          getAddress(address),
+          startBlock,
+        ]);
         setProposalsERC20VotingWeight(
           (pastVotingWeight / votesTokenDecimalsDenominator).toString(),
         );
@@ -73,7 +83,7 @@ export default function ProposalSummary({
     }
 
     loadProposalVotingWeight();
-  }, [address, startBlock, votesTokenDecimalsDenominator, baseContracts, votesToken]);
+  }, [address, publicClient, startBlock, votesToken, votesTokenDecimalsDenominator]);
 
   const isERC20 = type === GovernanceType.AZORIUS_ERC20;
   const isERC721 = type === GovernanceType.AZORIUS_ERC721;

--- a/src/components/ui/modals/UnwrapToken.tsx
+++ b/src/components/ui/modals/UnwrapToken.tsx
@@ -8,7 +8,6 @@ import { useAccount, useWalletClient } from 'wagmi';
 import * as Yup from 'yup';
 import VotesERC20WrapperAbi from '../../../assets/abi/VotesERC20Wrapper';
 import { useERC20LinearToken } from '../../../hooks/DAO/loaders/governance/useERC20LinearToken';
-import useSafeContracts from '../../../hooks/safe/useSafeContracts';
 import useApproval from '../../../hooks/utils/useApproval';
 import { useFormHelpers } from '../../../hooks/utils/useFormHelpers';
 import { useTransaction } from '../../../hooks/utils/useTransaction';
@@ -21,7 +20,6 @@ export function UnwrapToken({ close }: { close: () => void }) {
   const { governance, governanceContracts } = useFractal();
   const azoriusGovernance = governance as AzoriusGovernance;
   const { address: account } = useAccount();
-  const baseContracts = useSafeContracts();
   const { loadERC20TokenAccountData } = useERC20LinearToken({ onMount: false });
 
   const [, pending, contractCallViem] = useTransaction();
@@ -30,9 +28,7 @@ export function UnwrapToken({ close }: { close: () => void }) {
     approveTransaction,
     pending: approvalPending,
   } = useApproval(
-    baseContracts?.votesTokenMasterCopyContract?.asSigner.attach(
-      governanceContracts.underlyingTokenAddress!,
-    ),
+    governanceContracts.underlyingTokenAddress,
     azoriusGovernance.votesToken?.address,
   );
 

--- a/src/components/ui/modals/WrapToken.tsx
+++ b/src/components/ui/modals/WrapToken.tsx
@@ -9,7 +9,6 @@ import * as Yup from 'yup';
 import VotesERC20WrapperAbi from '../../../assets/abi/VotesERC20Wrapper';
 import { logError } from '../../../helpers/errorLogging';
 import { useERC20LinearToken } from '../../../hooks/DAO/loaders/governance/useERC20LinearToken';
-import useSafeContracts from '../../../hooks/safe/useSafeContracts';
 import useApproval from '../../../hooks/utils/useApproval';
 import { useFormHelpers } from '../../../hooks/utils/useFormHelpers';
 import { useTransaction } from '../../../hooks/utils/useTransaction';
@@ -30,7 +29,6 @@ export function WrapToken({ close }: { close: () => void }) {
     value: '',
     bigintValue: 0n,
   });
-  const baseContracts = useSafeContracts();
 
   const { loadERC20TokenAccountData } = useERC20LinearToken({ onMount: false });
   const [, pending, contractCallViem] = useTransaction();
@@ -39,9 +37,7 @@ export function WrapToken({ close }: { close: () => void }) {
     approveTransaction,
     pending: approvalPending,
   } = useApproval(
-    baseContracts?.votesTokenMasterCopyContract?.asSigner.attach(
-      governanceContracts.underlyingTokenAddress!,
-    ),
+    governanceContracts.underlyingTokenAddress,
     azoriusGovernance.votesToken?.address,
     userBalance.bigintValue,
   );
@@ -89,8 +85,7 @@ export function WrapToken({ close }: { close: () => void }) {
   const handleFormSubmit = useCallback(
     (amount: BigIntValuePair) => {
       const { votesTokenContractAddress } = governanceContracts;
-      if (!votesTokenContractAddress || !signer || !account || !baseContracts || !walletClient)
-        return;
+      if (!votesTokenContractAddress || !signer || !account || !walletClient) return;
 
       const wrapperTokenContract = getContract({
         abi: VotesERC20WrapperAbi,
@@ -119,7 +114,6 @@ export function WrapToken({ close }: { close: () => void }) {
       close,
       t,
       loadERC20TokenAccountData,
-      baseContracts,
       walletClient,
     ],
   );

--- a/src/hooks/DAO/loaders/governance/useERC20LinearToken.ts
+++ b/src/hooks/DAO/loaders/governance/useERC20LinearToken.ts
@@ -1,4 +1,3 @@
-import { DelegateChangedEvent } from '@fractal-framework/fractal-contracts/dist/typechain-types/contracts/VotesERC20';
 import { useCallback, useEffect, useRef } from 'react';
 import { getAddress } from 'viem';
 import { useFractal } from '../../../../providers/App/AppProvider';
@@ -76,20 +75,10 @@ export const useERC20LinearToken = ({ onMount = true }: { onMount?: boolean }) =
       (await tokenContract.getVotes(account)).toBigInt(),
     ]);
 
-    let delegateChangeEvents: DelegateChangedEvent[];
-    try {
-      delegateChangeEvents = await tokenContract.queryFilter(
-        tokenContract.filters.DelegateChanged(),
-      );
-    } catch (e) {
-      delegateChangeEvents = [];
-    }
-
     const tokenAccountData = {
       balance: tokenBalance,
       delegatee: tokenDelegatee,
       votingWeight: tokenVotingWeight,
-      isDelegatesSet: delegateChangeEvents.length > 0,
     };
 
     action.dispatch({

--- a/src/hooks/DAO/loaders/governance/useERC20LinearToken.ts
+++ b/src/hooks/DAO/loaders/governance/useERC20LinearToken.ts
@@ -1,8 +1,9 @@
-import { useCallback, useEffect, useRef } from 'react';
-import { getAddress } from 'viem';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { getAddress, getContract } from 'viem';
+import { usePublicClient } from 'wagmi';
+import VotesERC20Abi from '../../../../assets/abi/VotesERC20';
 import { useFractal } from '../../../../providers/App/AppProvider';
 import { FractalGovernanceAction } from '../../../../providers/App/governance/action';
-import useSafeContracts from '../../../safe/useSafeContracts';
 
 export const useERC20LinearToken = ({ onMount = true }: { onMount?: boolean }) => {
   const isTokenLoaded = useRef(false);
@@ -14,65 +15,84 @@ export const useERC20LinearToken = ({ onMount = true }: { onMount?: boolean }) =
     readOnly: { user },
   } = useFractal();
   const account = user.address;
-  const baseContracts = useSafeContracts();
+  const publicClient = usePublicClient();
 
-  const loadERC20Token = useCallback(async () => {
-    if (!votesTokenContractAddress || !baseContracts) {
+  const tokenContract = useMemo(() => {
+    if (!votesTokenContractAddress || !publicClient) {
       return;
     }
-    const tokenContract =
-      baseContracts.votesTokenMasterCopyContract.asProvider.attach(votesTokenContractAddress);
+
+    return getContract({
+      abi: VotesERC20Abi,
+      address: getAddress(votesTokenContractAddress),
+      client: publicClient,
+    });
+  }, [publicClient, votesTokenContractAddress]);
+
+  const underlyingTokenContract = useMemo(() => {
+    if (!underlyingTokenAddress || !publicClient) {
+      return;
+    }
+
+    return getContract({
+      abi: VotesERC20Abi,
+      address: getAddress(underlyingTokenAddress),
+      client: publicClient,
+    });
+  }, [publicClient, underlyingTokenAddress]);
+
+  const loadERC20Token = useCallback(async () => {
+    if (!tokenContract) {
+      return;
+    }
+
     const [tokenName, tokenSymbol, tokenDecimals, totalSupply] = await Promise.all([
-      tokenContract.name(),
-      tokenContract.symbol(),
-      tokenContract.decimals(),
-      (await tokenContract.totalSupply()).toBigInt(),
+      tokenContract.read.name(),
+      tokenContract.read.symbol(),
+      tokenContract.read.decimals(),
+      await tokenContract.read.totalSupply(),
     ]);
     const tokenData = {
       name: tokenName,
       symbol: tokenSymbol,
       decimals: tokenDecimals,
-      address: getAddress(votesTokenContractAddress),
+      address: tokenContract.address,
       totalSupply,
     };
     isTokenLoaded.current = true;
     action.dispatch({ type: FractalGovernanceAction.SET_TOKEN_DATA, payload: tokenData });
-  }, [votesTokenContractAddress, action, baseContracts]);
+  }, [tokenContract, action]);
 
   const loadUnderlyingERC20Token = useCallback(async () => {
-    if (!underlyingTokenAddress || !baseContracts) {
+    if (!underlyingTokenContract) {
       return;
     }
-    const tokenContract =
-      baseContracts.votesTokenMasterCopyContract.asProvider.attach(underlyingTokenAddress);
 
     const [tokenName, tokenSymbol] = await Promise.all([
-      tokenContract.name(),
-      tokenContract.symbol(),
+      underlyingTokenContract.read.name(),
+      underlyingTokenContract.read.symbol(),
     ]);
     const tokenData = {
       name: tokenName,
       symbol: tokenSymbol,
-      address: getAddress(underlyingTokenAddress),
+      address: underlyingTokenContract.address,
     };
     action.dispatch({
       type: FractalGovernanceAction.SET_UNDERLYING_TOKEN_DATA,
       payload: tokenData,
     });
-  }, [underlyingTokenAddress, action, baseContracts]);
+  }, [underlyingTokenContract, action]);
 
   const loadERC20TokenAccountData = useCallback(async () => {
-    if (!votesTokenContractAddress || !account || !baseContracts) {
+    if (!account || !tokenContract) {
       action.dispatch({ type: FractalGovernanceAction.RESET_TOKEN_ACCOUNT_DATA });
       return;
     }
-    const tokenContract =
-      baseContracts.votesTokenMasterCopyContract.asProvider.attach(votesTokenContractAddress);
-    // @todo We could probably save on some requests here.
+
     const [tokenBalance, tokenDelegatee, tokenVotingWeight] = await Promise.all([
-      (await tokenContract.balanceOf(account)).toBigInt(),
-      tokenContract.delegates(account),
-      (await tokenContract.getVotes(account)).toBigInt(),
+      tokenContract.read.balanceOf([getAddress(account)]),
+      tokenContract.read.delegates([getAddress(account)]),
+      tokenContract.read.getVotes([getAddress(account)]),
     ]);
 
     const tokenAccountData = {
@@ -85,7 +105,7 @@ export const useERC20LinearToken = ({ onMount = true }: { onMount?: boolean }) =
       type: FractalGovernanceAction.SET_TOKEN_ACCOUNT_DATA,
       payload: tokenAccountData,
     });
-  }, [votesTokenContractAddress, action, account, baseContracts]);
+  }, [account, tokenContract, action]);
 
   useEffect(() => {
     if (
@@ -100,49 +120,64 @@ export const useERC20LinearToken = ({ onMount = true }: { onMount?: boolean }) =
   }, [account, votesTokenContractAddress, onMount, loadERC20TokenAccountData]);
 
   useEffect(() => {
-    if (!votesTokenContractAddress || !onMount || !baseContracts) {
+    if (!onMount || !tokenContract || !account) {
       return;
     }
-    const tokenContract =
-      baseContracts.votesTokenMasterCopyContract.asProvider.attach(votesTokenContractAddress);
 
-    const delegateVotesChangedfilter = tokenContract.filters.DelegateVotesChanged();
-    tokenContract.on(delegateVotesChangedfilter, loadERC20TokenAccountData);
+    const unwatch = tokenContract.watchEvent.DelegateVotesChanged(
+      { delegate: getAddress(account) },
+      { onLogs: loadERC20TokenAccountData },
+    );
 
     return () => {
-      tokenContract.off(delegateVotesChangedfilter, loadERC20TokenAccountData);
+      unwatch();
     };
-  }, [votesTokenContractAddress, loadERC20TokenAccountData, onMount, baseContracts]);
+  }, [loadERC20TokenAccountData, onMount, tokenContract, account]);
 
   useEffect(() => {
-    if (!votesTokenContractAddress || !onMount || !baseContracts) {
+    if (!tokenContract || !onMount || !account) {
       return;
     }
-    const tokenContract =
-      baseContracts.votesTokenMasterCopyContract.asProvider.attach(votesTokenContractAddress);
-    const delegateChangedfilter = tokenContract.filters.DelegateChanged();
-    tokenContract.on(delegateChangedfilter, loadERC20TokenAccountData);
+
+    const unwatchDelegator = tokenContract.watchEvent.DelegateChanged(
+      { delegator: getAddress(account) },
+      { onLogs: loadERC20TokenAccountData },
+    );
+    const unwatchFromDelegate = tokenContract.watchEvent.DelegateChanged(
+      { fromDelegate: getAddress(account) },
+      { onLogs: loadERC20TokenAccountData },
+    );
+    const unwatchToDelegate = tokenContract.watchEvent.DelegateChanged(
+      { toDelegate: getAddress(account) },
+      { onLogs: loadERC20TokenAccountData },
+    );
 
     return () => {
-      tokenContract.off(delegateChangedfilter, loadERC20TokenAccountData);
+      unwatchDelegator();
+      unwatchFromDelegate();
+      unwatchToDelegate();
     };
-  }, [votesTokenContractAddress, loadERC20TokenAccountData, onMount, baseContracts]);
+  }, [account, loadERC20TokenAccountData, onMount, tokenContract]);
 
   useEffect(() => {
-    if (!votesTokenContractAddress || !onMount || !baseContracts) {
+    if (!onMount || !account || !tokenContract) {
       return;
     }
-    const tokenContract =
-      baseContracts.votesTokenMasterCopyContract.asProvider.attach(votesTokenContractAddress);
-    const filterTo = tokenContract.filters.Transfer(null, account);
-    const filterFrom = tokenContract.filters.Transfer(account, null);
-    tokenContract.on(filterTo, loadERC20TokenAccountData);
-    tokenContract.on(filterFrom, loadERC20TokenAccountData);
+
+    const unwatchTo = tokenContract.watchEvent.Transfer(
+      { from: getAddress(account) },
+      { onLogs: loadERC20TokenAccountData },
+    );
+    const unwatchFrom = tokenContract.watchEvent.Transfer(
+      { to: getAddress(account) },
+      { onLogs: loadERC20TokenAccountData },
+    );
+
     return () => {
-      tokenContract.off(filterTo, loadERC20TokenAccountData);
-      tokenContract.off(filterFrom, loadERC20TokenAccountData);
+      unwatchTo();
+      unwatchFrom();
     };
-  }, [votesTokenContractAddress, account, onMount, loadERC20TokenAccountData, baseContracts]);
+  }, [account, loadERC20TokenAccountData, onMount, tokenContract]);
 
   return { loadERC20Token, loadUnderlyingERC20Token, loadERC20TokenAccountData };
 };

--- a/src/hooks/DAO/loaders/governance/useERC721Tokens.ts
+++ b/src/hooks/DAO/loaders/governance/useERC721Tokens.ts
@@ -1,22 +1,20 @@
-import { ERC721__factory } from '@fractal-framework/fractal-contracts';
 import { useCallback } from 'react';
-import { getAddress, zeroAddress } from 'viem';
-import { logError } from '../../../../helpers/errorLogging';
+import { erc721Abi, getAddress, getContract, zeroAddress } from 'viem';
+import { usePublicClient } from 'wagmi';
 import { useFractal } from '../../../../providers/App/AppProvider';
 import { FractalGovernanceAction } from '../../../../providers/App/governance/action';
 import { ERC721TokenData } from '../../../../types';
 import useSafeContracts from '../../../safe/useSafeContracts';
-import useSignerOrProvider from '../../../utils/useSignerOrProvider';
 
 export default function useERC721Tokens() {
-  const signerOrProvider = useSignerOrProvider();
   const {
     governanceContracts: { erc721LinearVotingContractAddress },
     action,
   } = useFractal();
   const baseContracts = useSafeContracts();
+  const publicClient = usePublicClient();
   const loadERC721Tokens = useCallback(async () => {
-    if (!erc721LinearVotingContractAddress || !signerOrProvider || !baseContracts) {
+    if (!erc721LinearVotingContractAddress || !baseContracts || !publicClient) {
       return;
     }
     const erc721LinearVotingContract =
@@ -26,22 +24,19 @@ export default function useERC721Tokens() {
     const addresses = await erc721LinearVotingContract.getAllTokenAddresses();
     const erc721Tokens: ERC721TokenData[] = await Promise.all(
       addresses.map(async address => {
-        const tokenContract = ERC721__factory.connect(address, signerOrProvider);
+        const tokenContract = getContract({
+          abi: erc721Abi,
+          address: getAddress(address),
+          client: publicClient,
+        });
         const votingWeight = (await erc721LinearVotingContract.getTokenWeight(address)).toBigInt();
-        const name = await tokenContract.name();
-        const symbol = await tokenContract.symbol();
-        let totalSupply = undefined;
-        try {
-          const tokenMintEvents = await tokenContract.queryFilter(
-            tokenContract.filters.Transfer(zeroAddress, null),
-          );
-          const tokenBurnEvents = await tokenContract.queryFilter(
-            tokenContract.filters.Transfer(null, zeroAddress),
-          );
-          totalSupply = BigInt(tokenMintEvents.length - tokenBurnEvents.length);
-        } catch (e) {
-          logError('Error while getting ERC721 total supply');
-        }
+        const [name, symbol, tokenMintEvents, tokenBurnEvents] = await Promise.all([
+          tokenContract.read.name(),
+          tokenContract.read.symbol(),
+          tokenContract.getEvents.Transfer({ from: zeroAddress }),
+          tokenContract.getEvents.Transfer({ to: zeroAddress }),
+        ]);
+        const totalSupply = BigInt(tokenMintEvents.length - tokenBurnEvents.length);
         return { name, symbol, address: getAddress(address), votingWeight, totalSupply };
       }),
     );
@@ -50,7 +45,7 @@ export default function useERC721Tokens() {
       type: FractalGovernanceAction.SET_ERC721_TOKENS_DATA,
       payload: erc721Tokens,
     });
-  }, [erc721LinearVotingContractAddress, signerOrProvider, action, baseContracts]);
+  }, [action, baseContracts, erc721LinearVotingContractAddress, publicClient]);
 
   return loadERC721Tokens;
 }

--- a/src/hooks/DAO/loaders/governance/useLockRelease.ts
+++ b/src/hooks/DAO/loaders/governance/useLockRelease.ts
@@ -1,4 +1,3 @@
-import { DelegateChangedEvent } from '@fractal-framework/fractal-contracts/dist/typechain-types/contracts/VotesERC20';
 import { useCallback, useEffect, useRef } from 'react';
 import { LockRelease__factory } from '../../../../assets/typechain-types/dcnt';
 import { useFractal } from '../../../../providers/App/AppProvider';
@@ -35,20 +34,10 @@ export const useLockRelease = ({ onMount = true }: { onMount?: boolean }) => {
         (await lockReleaseContract.getVotes(account)).toBigInt(),
       ]);
 
-    let delegateChangeEvents: DelegateChangedEvent[];
-    try {
-      delegateChangeEvents = await lockReleaseContract.queryFilter(
-        lockReleaseContract.filters.DelegateChanged(),
-      );
-    } catch (e) {
-      delegateChangeEvents = [];
-    }
-
     const tokenAccountData = {
       balance: tokenAmountTotal - tokenAmountReleased,
       delegatee: tokenDelegatee,
       votingWeight: tokenVotingWeight,
-      isDelegatesSet: delegateChangeEvents.length > 0,
     };
     action.dispatch({
       type: DecentGovernanceAction.SET_LOCKED_TOKEN_ACCOUNT_DATA,

--- a/src/hooks/DAO/loaders/useFractalFreeze.ts
+++ b/src/hooks/DAO/loaders/useFractalFreeze.ts
@@ -6,8 +6,9 @@ import {
 import { TypedListener } from '@fractal-framework/fractal-contracts/dist/typechain-types/common';
 import { FreezeVoteCastEvent } from '@fractal-framework/fractal-contracts/dist/typechain-types/contracts/ERC20FreezeVoting';
 import { useCallback, useEffect, useRef } from 'react';
-import { zeroAddress } from 'viem';
-import { useAccount } from 'wagmi';
+import { getAddress, getContract, zeroAddress } from 'viem';
+import { useAccount, usePublicClient } from 'wagmi';
+import VotesERC20Abi from '../../../assets/abi/VotesERC20';
 import {
   isWithinFreezeProposalPeriod,
   isWithinFreezePeriod,
@@ -42,6 +43,7 @@ export const useFractalFreeze = ({
   );
 
   const provider = useEthersProvider();
+  const publicClient = usePublicClient();
 
   const loadFractalFreezeGuard = useCallback(
     async ({
@@ -53,7 +55,8 @@ export const useFractalFreeze = ({
         !freezeVotingContractAddress ||
         !account ||
         !provider ||
-        !baseContracts
+        !baseContracts ||
+        !publicClient
       ) {
         return;
       }
@@ -95,11 +98,7 @@ export const useFractalFreeze = ({
         isFrozen,
       };
 
-      const {
-        votesTokenMasterCopyContract,
-        safeSingletonContract,
-        freezeERC20VotingMasterCopyContract,
-      } = baseContracts;
+      const { safeSingletonContract, freezeERC20VotingMasterCopyContract } = baseContracts;
 
       if (freezeVotingType === FreezeVotingType.MULTISIG) {
         const safeContract = safeSingletonContract!.asProvider.attach(
@@ -111,9 +110,13 @@ export const useFractalFreeze = ({
         const freezeERC20VotingContract = freezeERC20VotingMasterCopyContract.asProvider.attach(
           freezeVotingContractAddress,
         );
-        const votesTokenContract = votesTokenMasterCopyContract!.asProvider.attach(
-          await freezeERC20VotingContract.votesERC20(),
-        );
+
+        const votesTokenContract = getContract({
+          abi: VotesERC20Abi,
+          address: getAddress(await freezeERC20VotingContract.votesERC20()),
+          client: publicClient,
+        });
+
         const currentTimestamp = await getTimeStamp('latest', provider);
         const isFreezeActive =
           isWithinFreezeProposalPeriod(
@@ -129,11 +132,13 @@ export const useFractalFreeze = ({
         userHasVotes =
           (!isFreezeActive
             ? // freeze not active
-              (await votesTokenContract.getVotes(account || '')).toBigInt()
+              // TODO should this be a comparison??
+              await votesTokenContract.read.getVotes([account || ''])
             : // freeze is active
-              (
-                await votesTokenContract.getPastVotes(account || '', freezeCreatedBlock)
-              ).toBigInt()) > 0n;
+              await votesTokenContract.read.getPastVotes([
+                account || '',
+                BigInt(freezeCreatedBlock),
+              ])) > 0n;
       } else if (freezeVotingType === FreezeVotingType.ERC721) {
         const { totalVotingTokenAddresses } = await getUserERC721VotingTokens(
           undefined,
@@ -149,7 +154,7 @@ export const useFractalFreeze = ({
       isFreezeSet.current = true;
       return freeze;
     },
-    [account, provider, baseContracts, getUserERC721VotingTokens, parentSafeAddress],
+    [account, provider, baseContracts, publicClient, getUserERC721VotingTokens, parentSafeAddress],
   );
 
   const setFractalFreezeGuard = useCallback(

--- a/src/hooks/DAO/proposal/useUserERC721VotingTokens.ts
+++ b/src/hooks/DAO/proposal/useUserERC721VotingTokens.ts
@@ -6,7 +6,6 @@ import {
 } from '@fractal-framework/fractal-contracts';
 import { useState, useEffect, useCallback } from 'react';
 import { getAddress } from 'viem';
-import { logError } from '../../../helpers/errorLogging';
 import { useFractal } from '../../../providers/App/AppProvider';
 import { useSafeAPI } from '../../../providers/App/hooks/useSafeAPI';
 import { AzoriusGovernance } from '../../../types';
@@ -91,16 +90,7 @@ export default function useUserERC721VotingTokens(
               const votingWeight = (await votingContract!.getTokenWeight(tokenAddress)).toBigInt();
               const name = await tokenContract.name();
               const symbol = await tokenContract.symbol();
-              let totalSupply = undefined;
-              try {
-                const tokenSentEvents = await tokenContract.queryFilter(
-                  tokenContract.filters.Transfer(null, null),
-                );
-                totalSupply = BigInt(tokenSentEvents.length);
-              } catch (e) {
-                logError('Error while getting ERC721 total supply');
-              }
-              return { name, symbol, address: getAddress(tokenAddress), votingWeight, totalSupply };
+              return { name, symbol, address: getAddress(tokenAddress), votingWeight };
             }),
           );
         }

--- a/src/hooks/DAO/useBuildDAOTx.ts
+++ b/src/hooks/DAO/useBuildDAOTx.ts
@@ -1,4 +1,5 @@
 import { useCallback } from 'react';
+import { usePublicClient } from 'wagmi';
 import { TxBuilderFactory } from '../../models/TxBuilderFactory';
 import { useFractal } from '../../providers/App/AppProvider';
 import { useNetworkConfig } from '../../providers/NetworkConfig/NetworkConfigProvider';
@@ -27,6 +28,7 @@ const useBuildDAOTx = () => {
     governance,
     governanceContracts: { erc721LinearVotingContractAddress },
   } = useFractal();
+  const publicClient = usePublicClient();
 
   const buildDao = useCallback(
     async (
@@ -36,7 +38,7 @@ const useBuildDAOTx = () => {
     ) => {
       let azoriusContracts: AzoriusContracts | undefined;
 
-      if (!user.address || !signerOrProvider || !baseContracts) {
+      if (!user.address || !signerOrProvider || !baseContracts || !publicClient) {
         return;
       }
       const {
@@ -102,6 +104,7 @@ const useBuildDAOTx = () => {
 
       const txBuilderFactory = new TxBuilderFactory(
         signerOrProvider,
+        publicClient,
         buildrerBaseContracts,
         azoriusContracts,
         daoData,
@@ -148,6 +151,7 @@ const useBuildDAOTx = () => {
     [
       user.address,
       signerOrProvider,
+      publicClient,
       baseContracts,
       erc721LinearVotingContractAddress,
       dao,

--- a/src/hooks/DAO/useBuildDAOTx.ts
+++ b/src/hooks/DAO/useBuildDAOTx.ts
@@ -18,7 +18,7 @@ const useBuildDAOTx = () => {
   const signerOrProvider = useSignerOrProvider();
   const {
     createOptions,
-    contracts: { fallbackHandler, votesERC20WrapperMasterCopy },
+    contracts: { fallbackHandler, votesERC20WrapperMasterCopy, votesERC20MasterCopy },
   } = useNetworkConfig();
 
   const {
@@ -54,7 +54,6 @@ const useBuildDAOTx = () => {
         freezeMultisigVotingMasterCopyContract,
         freezeERC20VotingMasterCopyContract,
         freezeERC721VotingMasterCopyContract,
-        votesTokenMasterCopyContract,
         claimingMasterCopyContract,
         keyValuePairsContract,
       } = baseContracts;
@@ -72,7 +71,6 @@ const useBuildDAOTx = () => {
         if (
           !fractalAzoriusMasterCopyContract ||
           !linearVotingMasterCopyContract ||
-          !votesTokenMasterCopyContract ||
           !azoriusFreezeGuardMasterCopyContract ||
           !claimingMasterCopyContract
         ) {
@@ -84,7 +82,6 @@ const useBuildDAOTx = () => {
           linearVotingMasterCopyContract: linearVotingMasterCopyContract.asSigner,
           linearVotingERC721MasterCopyContract: linearVotingERC721MasterCopyContract.asSigner,
           azoriusFreezeGuardMasterCopyContract: azoriusFreezeGuardMasterCopyContract.asSigner,
-          votesTokenMasterCopyContract: votesTokenMasterCopyContract.asSigner,
           claimingMasterCopyContract: claimingMasterCopyContract.asSigner,
         };
       }
@@ -110,6 +107,7 @@ const useBuildDAOTx = () => {
         daoData,
         fallbackHandler,
         votesERC20WrapperMasterCopy,
+        votesERC20MasterCopy,
         parentAddress,
         parentTokenAddress,
       );
@@ -157,6 +155,7 @@ const useBuildDAOTx = () => {
       createOptions,
       fallbackHandler,
       votesERC20WrapperMasterCopy,
+      votesERC20MasterCopy,
     ],
   );
 

--- a/src/hooks/DAO/useClawBack.ts
+++ b/src/hooks/DAO/useClawBack.ts
@@ -1,7 +1,15 @@
-import { ERC20__factory, FractalModule } from '@fractal-framework/fractal-contracts';
+import { FractalModule } from '@fractal-framework/fractal-contracts';
 import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Address, encodeAbiParameters, getAddress, isHex, parseAbiParameters } from 'viem';
+import {
+  Address,
+  encodeAbiParameters,
+  encodeFunctionData,
+  erc20Abi,
+  getAddress,
+  isHex,
+  parseAbiParameters,
+} from 'viem';
 import { useSafeAPI } from '../../providers/App/hooks/useSafeAPI';
 import { useEthersProvider } from '../../providers/Ethers/hooks/useEthersProvider';
 import { FractalModuleType, FractalNode } from '../../types';
@@ -54,14 +62,11 @@ export default function useClawBack({ childSafeInfo, parentAddress }: IUseClawBa
                 calldata: fractalModuleCalldata,
               };
             } else {
-              const tokenContract = ERC20__factory.connect(asset.tokenAddress, provider);
-              const clawBackCalldata = tokenContract.interface.encodeFunctionData('transfer', [
-                parentAddress,
-                asset.balance,
-              ]);
-              if (!isHex(clawBackCalldata)) {
-                throw new Error('Error encoding clawback call data');
-              }
+              const clawBackCalldata = encodeFunctionData({
+                abi: erc20Abi,
+                functionName: 'transfer',
+                args: [parentAddress, BigInt(asset.balance)],
+              });
               const txData = encodeAbiParameters(
                 parseAbiParameters('address, uint256, bytes, uint8'),
                 [getAddress(asset.tokenAddress), 0n, clawBackCalldata, 0],

--- a/src/hooks/DAO/useDelegateVote.ts
+++ b/src/hooks/DAO/useDelegateVote.ts
@@ -1,4 +1,3 @@
-import { VotesERC20 } from '@fractal-framework/fractal-contracts';
 import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { LockRelease } from '../../assets/typechain-types/dcnt';
@@ -16,7 +15,7 @@ const useDelegateVote = () => {
       successCallback,
     }: {
       delegatee: string;
-      votingTokenContract: VotesERC20 | LockRelease;
+      votingTokenContract: LockRelease;
       successCallback?: () => void;
     }) => {
       contractCallDelegateVote({

--- a/src/hooks/DAO/useDeployAzorius.ts
+++ b/src/hooks/DAO/useDeployAzorius.ts
@@ -21,7 +21,7 @@ const useDeployAzorius = () => {
   const signerOrProvider = useSignerOrProvider();
   const navigate = useNavigate();
   const {
-    contracts: { fallbackHandler, votesERC20WrapperMasterCopy },
+    contracts: { fallbackHandler, votesERC20WrapperMasterCopy, votesERC20MasterCopy },
     addressPrefix,
   } = useNetworkConfig();
   const {
@@ -54,7 +54,6 @@ const useDeployAzorius = () => {
         azoriusFreezeGuardMasterCopyContract,
         freezeMultisigVotingMasterCopyContract,
         freezeERC20VotingMasterCopyContract,
-        votesTokenMasterCopyContract,
         claimingMasterCopyContract,
         keyValuePairsContract,
       } = baseContracts;
@@ -64,7 +63,6 @@ const useDeployAzorius = () => {
         fractalAzoriusMasterCopyContract: fractalAzoriusMasterCopyContract.asProvider,
         linearVotingMasterCopyContract: linearVotingMasterCopyContract.asProvider,
         azoriusFreezeGuardMasterCopyContract: azoriusFreezeGuardMasterCopyContract.asProvider,
-        votesTokenMasterCopyContract: votesTokenMasterCopyContract.asProvider,
         claimingMasterCopyContract: claimingMasterCopyContract.asProvider,
       } as AzoriusContracts;
 
@@ -88,6 +86,7 @@ const useDeployAzorius = () => {
         daoData,
         fallbackHandler,
         votesERC20WrapperMasterCopy,
+        votesERC20MasterCopy,
         undefined,
         undefined,
       );
@@ -146,6 +145,7 @@ const useDeployAzorius = () => {
       fallbackHandler,
       addressPrefix,
       votesERC20WrapperMasterCopy,
+      votesERC20MasterCopy,
     ],
   );
 

--- a/src/hooks/DAO/useDeployAzorius.ts
+++ b/src/hooks/DAO/useDeployAzorius.ts
@@ -2,6 +2,7 @@ import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import { getAddress, isHex } from 'viem';
+import { usePublicClient } from 'wagmi';
 import { DAO_ROUTES } from '../../constants/routes';
 import { TxBuilderFactory } from '../../models/TxBuilderFactory';
 import { useFractal } from '../../providers/App/AppProvider';
@@ -32,13 +33,15 @@ const useDeployAzorius = () => {
   const { t } = useTranslation(['transaction', 'proposalMetadata']);
   const { submitProposal } = useSubmitProposal();
   const { canUserCreateProposal } = useCanUserCreateProposal();
+  const publicClient = usePublicClient();
+
   const deployAzorius = useCallback(
     async (
       daoData: AzoriusERC20DAO | AzoriusERC721DAO,
       shouldSetName?: boolean,
       shouldSetSnapshot?: boolean,
     ) => {
-      if (!daoAddress || !canUserCreateProposal || !safe || !baseContracts) {
+      if (!daoAddress || !canUserCreateProposal || !safe || !baseContracts || !publicClient) {
         return;
       }
       const {
@@ -81,6 +84,7 @@ const useDeployAzorius = () => {
 
       const txBuilderFactory = new TxBuilderFactory(
         signerOrProvider,
+        publicClient,
         builderBaseContracts,
         azoriusContracts,
         daoData,
@@ -135,6 +139,7 @@ const useDeployAzorius = () => {
     },
     [
       signerOrProvider,
+      publicClient,
       baseContracts,
       t,
       canUserCreateProposal,

--- a/src/hooks/safe/useSafeContracts.ts
+++ b/src/hooks/safe/useSafeContracts.ts
@@ -5,7 +5,6 @@ import {
   ERC20FreezeVoting__factory,
   MultisigFreezeGuard__factory,
   MultisigFreezeVoting__factory,
-  VotesERC20__factory,
   GnosisSafeProxyFactory__factory,
   ModuleProxyFactory__factory,
   LinearERC20Voting__factory,
@@ -41,7 +40,6 @@ export default function useSafeContracts() {
       multisigFreezeVotingMasterCopy,
       erc20FreezeVotingMasterCopy,
       erc721FreezeVotingMasterCopy,
-      votesERC20MasterCopy,
       claimingMasterCopy,
       linearVotingERC721MasterCopy,
       keyValuePairs,
@@ -127,11 +125,6 @@ export default function useSafeContracts() {
       asProvider: ERC721FreezeVoting__factory.connect(erc721FreezeVotingMasterCopy, provider),
     };
 
-    const votesTokenMasterCopyContract = {
-      asSigner: VotesERC20__factory.connect(votesERC20MasterCopy, signerOrProvider),
-      asProvider: VotesERC20__factory.connect(votesERC20MasterCopy, provider),
-    };
-
     const claimingMasterCopyContract = {
       asSigner: ERC20Claim__factory.connect(claimingMasterCopy, signerOrProvider),
       asProvider: ERC20Claim__factory.connect(claimingMasterCopy, provider),
@@ -156,7 +149,6 @@ export default function useSafeContracts() {
       freezeMultisigVotingMasterCopyContract,
       freezeERC20VotingMasterCopyContract,
       freezeERC721VotingMasterCopyContract,
-      votesTokenMasterCopyContract,
       claimingMasterCopyContract,
       linearVotingERC721MasterCopyContract,
       keyValuePairsContract,
@@ -174,7 +166,6 @@ export default function useSafeContracts() {
     azoriusFreezeGuardMasterCopy,
     multisigFreezeVotingMasterCopy,
     erc20FreezeVotingMasterCopy,
-    votesERC20MasterCopy,
     claimingMasterCopy,
     linearVotingERC721MasterCopy,
     erc721FreezeVotingMasterCopy,

--- a/src/hooks/utils/useApproval.tsx
+++ b/src/hooks/utils/useApproval.tsx
@@ -1,29 +1,42 @@
-import { VotesERC20 } from '@fractal-framework/fractal-contracts';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { maxUint256 } from 'viem';
-import { useAccount } from 'wagmi';
+import { getAddress, getContract, maxUint256 } from 'viem';
+import { useAccount, useWalletClient } from 'wagmi';
+import VotesERC20Abi from '../../assets/abi/VotesERC20';
 import { useTransaction } from './useTransaction';
 
-const useApproval = (tokenContract?: VotesERC20, spenderAddress?: string, userBalance?: bigint) => {
+const useApproval = (tokenAddress?: string, spenderAddress?: string, userBalance?: bigint) => {
   const { address: account } = useAccount();
   const [allowance, setAllowance] = useState(0n);
   const [approved, setApproved] = useState(false);
-  const [contractCall, pending] = useTransaction();
+  const [, pending, contractCallViem] = useTransaction();
   const { t } = useTranslation('treasury');
+  const { data: walletClient } = useWalletClient();
+
+  const tokenContract = useMemo(() => {
+    if (!walletClient || !tokenAddress) {
+      return;
+    }
+
+    return getContract({
+      abi: VotesERC20Abi,
+      address: getAddress(tokenAddress),
+      client: walletClient,
+    });
+  }, [tokenAddress, walletClient]);
 
   const fetchAllowance = useCallback(async () => {
-    if (!tokenContract || !account || !spenderAddress) return;
+    if (!account || !spenderAddress || !tokenContract) return;
 
-    const userAllowance = (await tokenContract.allowance(account, spenderAddress)).toBigInt();
+    const userAllowance = await tokenContract.read.allowance([account, getAddress(spenderAddress)]);
     setAllowance(userAllowance);
   }, [account, tokenContract, spenderAddress]);
 
   const approveTransaction = useCallback(async () => {
     if (!tokenContract || !account || !spenderAddress) return;
 
-    contractCall({
-      contractFn: () => tokenContract.approve(spenderAddress, maxUint256),
+    contractCallViem({
+      contractFn: () => tokenContract.write.approve([getAddress(spenderAddress), maxUint256]),
       pendingMessage: t('approvalPendingMessage'),
       failedMessage: t('approvalFailedMessage'),
       successMessage: t('approvalSuccessMessage'),
@@ -31,7 +44,7 @@ const useApproval = (tokenContract?: VotesERC20, spenderAddress?: string, userBa
         setApproved(true);
       },
     });
-  }, [account, contractCall, tokenContract, spenderAddress, t]);
+  }, [account, contractCallViem, tokenContract, spenderAddress, t]);
 
   useEffect(() => {
     fetchAllowance();

--- a/src/models/AzoriusTxBuilder.ts
+++ b/src/models/AzoriusTxBuilder.ts
@@ -21,6 +21,7 @@ import {
   isHex,
   encodeFunctionData,
 } from 'viem';
+import VotesERC20Abi from '../assets/abi/VotesERC20';
 import VotesERC20WrapperAbi from '../assets/abi/VotesERC20Wrapper';
 import { GnosisSafeL2 } from '../assets/typechain-types/usul/@gnosis.pm/safe-contracts/contracts';
 import { buildContractCall, getRandomBytes } from '../helpers';
@@ -56,6 +57,7 @@ export class AzoriusTxBuilder extends BaseTxBuilder {
   public votesTokenContract: VotesERC20 | undefined;
 
   private votesERC20WrapperMasterCopyAddress: string;
+  private votesERC20MasterCopyAddress: string;
 
   private tokenNonce: bigint;
   private strategyNonce: bigint;
@@ -69,6 +71,7 @@ export class AzoriusTxBuilder extends BaseTxBuilder {
     daoData: AzoriusERC20DAO | AzoriusERC721DAO,
     safeContract: GnosisSafeL2,
     votesERC20WrapperMasterCopyAddress: string,
+    votesERC20MasterCopyAddress: string,
     parentAddress?: Address,
     parentTokenAddress?: Address,
   ) {
@@ -89,6 +92,7 @@ export class AzoriusTxBuilder extends BaseTxBuilder {
     this.azoriusNonce = getRandomBytes();
 
     this.votesERC20WrapperMasterCopyAddress = votesERC20WrapperMasterCopyAddress;
+    this.votesERC20MasterCopyAddress = votesERC20MasterCopyAddress;
 
     if (daoData.votingStrategyType === VotingStrategyType.LINEAR_ERC20) {
       daoData = daoData as AzoriusERC20DAO;
@@ -187,11 +191,7 @@ export class AzoriusTxBuilder extends BaseTxBuilder {
     return buildContractCall(
       this.baseContracts.zodiacModuleProxyFactoryContract,
       'deployModule',
-      [
-        this.azoriusContracts!.votesTokenMasterCopyContract.address,
-        this.encodedSetupTokenData,
-        this.tokenNonce,
-      ],
+      [this.votesERC20MasterCopyAddress, this.encodedSetupTokenData, this.tokenNonce],
       0,
       false,
     );
@@ -345,19 +345,16 @@ export class AzoriusTxBuilder extends BaseTxBuilder {
       ],
     );
 
-    const encodedSetupTokenData =
-      this.azoriusContracts!.votesTokenMasterCopyContract.interface.encodeFunctionData('setUp', [
-        encodedInitTokenData,
-      ]);
-    if (!isHex(encodedSetupTokenData)) {
-      throw new Error('Error encoding setup token data');
-    }
-    this.encodedSetupTokenData = encodedSetupTokenData;
+    this.encodedSetupTokenData = encodeFunctionData({
+      abi: VotesERC20Abi,
+      functionName: 'setUp',
+      args: [encodedInitTokenData],
+    });
   }
 
   private setPredictedTokenAddress() {
     const tokenByteCodeLinear = generateContractByteCodeLinear(
-      getAddress(this.azoriusContracts!.votesTokenMasterCopyContract.address),
+      getAddress(this.votesERC20MasterCopyAddress),
     );
 
     const tokenSalt = generateSalt(this.encodedSetupTokenData!, this.tokenNonce);

--- a/src/models/BaseTxBuilder.ts
+++ b/src/models/BaseTxBuilder.ts
@@ -1,4 +1,5 @@
 import { ethers } from 'ethers';
+import { PublicClient } from 'viem';
 import {
   BaseContracts,
   AzoriusContracts,
@@ -10,6 +11,7 @@ import {
 
 export class BaseTxBuilder {
   protected readonly signerOrProvider: ethers.Signer | any;
+  protected readonly publicClient: PublicClient;
   protected readonly baseContracts: BaseContracts;
   protected readonly azoriusContracts: AzoriusContracts | undefined;
   protected readonly daoData: SafeMultisigDAO | AzoriusERC20DAO | AzoriusERC721DAO | SubDAO;
@@ -18,6 +20,7 @@ export class BaseTxBuilder {
 
   constructor(
     signerOrProvider: ethers.Signer | any,
+    publicClient: PublicClient,
     baseContracts: BaseContracts,
     azoriusContracts: AzoriusContracts | undefined,
     daoData: SafeMultisigDAO | AzoriusERC20DAO | AzoriusERC721DAO | SubDAO,
@@ -25,6 +28,7 @@ export class BaseTxBuilder {
     parentTokenAddress?: string,
   ) {
     this.signerOrProvider = signerOrProvider;
+    this.publicClient = publicClient;
     this.baseContracts = baseContracts;
     this.daoData = daoData;
     this.azoriusContracts = azoriusContracts;

--- a/src/models/DaoTxBuilder.ts
+++ b/src/models/DaoTxBuilder.ts
@@ -1,5 +1,5 @@
 import { ethers } from 'ethers';
-import { zeroAddress } from 'viem';
+import { PublicClient, zeroAddress } from 'viem';
 import { GnosisSafeL2 } from '../assets/typechain-types/usul/@gnosis.pm/safe-contracts/contracts';
 import { buildContractCall, encodeMultiSend } from '../helpers';
 import {
@@ -34,6 +34,7 @@ export class DaoTxBuilder extends BaseTxBuilder {
 
   constructor(
     signerOrProvider: ethers.Signer | any,
+    publicClient: PublicClient,
     baseContracts: BaseContracts,
     azoriusContracts: AzoriusContracts | undefined,
     daoData: SafeMultisigDAO | AzoriusERC20DAO | AzoriusERC721DAO,
@@ -48,6 +49,7 @@ export class DaoTxBuilder extends BaseTxBuilder {
   ) {
     super(
       signerOrProvider,
+      publicClient,
       baseContracts,
       azoriusContracts,
       daoData,
@@ -131,9 +133,9 @@ export class DaoTxBuilder extends BaseTxBuilder {
     // If subDAO and parentAllocation, deploy claim module
     let tokenClaimTx: SafeTransaction | undefined;
     const parentAllocation = (this.daoData as AzoriusERC20DAO).parentAllocationAmount;
-    if (this.parentTokenAddress && parentAllocation && parentAllocation !== 0n) {
+    const tokenApprovalTx = azoriusTxBuilder.buildApproveClaimAllocation();
+    if (this.parentTokenAddress && parentAllocation && parentAllocation !== 0n && tokenApprovalTx) {
       tokenClaimTx = azoriusTxBuilder.buildDeployTokenClaim();
-      const tokenApprovalTx = azoriusTxBuilder.buildApproveClaimAllocation();
       this.internalTxs.push(tokenApprovalTx);
     }
 

--- a/src/models/FreezeGuardTxBuilder.ts
+++ b/src/models/FreezeGuardTxBuilder.ts
@@ -19,6 +19,7 @@ import {
   encodeAbiParameters,
   parseAbiParameters,
   isHex,
+  PublicClient,
 } from 'viem';
 import { GnosisSafeL2 } from '../assets/typechain-types/usul/@gnosis.pm/safe-contracts/contracts';
 import { buildContractCall } from '../helpers';
@@ -62,6 +63,7 @@ export class FreezeGuardTxBuilder extends BaseTxBuilder {
 
   constructor(
     signerOrProvider: any,
+    publicClient: PublicClient,
     baseContracts: BaseContracts,
     daoData: SubDAO,
     safeContract: GnosisSafeL2,
@@ -76,6 +78,7 @@ export class FreezeGuardTxBuilder extends BaseTxBuilder {
   ) {
     super(
       signerOrProvider,
+      publicClient,
       baseContracts,
       azoriusContracts,
       daoData,

--- a/src/models/TxBuilderFactory.ts
+++ b/src/models/TxBuilderFactory.ts
@@ -1,5 +1,5 @@
 import { ethers } from 'ethers';
-import { getAddress } from 'viem';
+import { PublicClient, getAddress } from 'viem';
 import { GnosisSafeL2 } from '../assets/typechain-types/usul/@gnosis.pm/safe-contracts/contracts';
 import { GnosisSafeL2__factory } from '../assets/typechain-types/usul/factories/@gnosis.pm/safe-contracts/contracts';
 import { getRandomBytes } from '../helpers';
@@ -34,6 +34,7 @@ export class TxBuilderFactory extends BaseTxBuilder {
 
   constructor(
     signerOrProvider: ethers.Signer | any,
+    publicClient: PublicClient,
     baseContracts: BaseContracts,
     azoriusContracts: AzoriusContracts | undefined,
     daoData: SafeMultisigDAO | AzoriusERC20DAO | AzoriusERC721DAO | SubDAO,
@@ -45,6 +46,7 @@ export class TxBuilderFactory extends BaseTxBuilder {
   ) {
     super(
       signerOrProvider,
+      publicClient,
       baseContracts,
       azoriusContracts,
       daoData,
@@ -86,6 +88,7 @@ export class TxBuilderFactory extends BaseTxBuilder {
   ): DaoTxBuilder {
     return new DaoTxBuilder(
       this.signerOrProvider,
+      this.publicClient,
       this.baseContracts,
       this.azoriusContracts,
       this.daoData,
@@ -108,6 +111,7 @@ export class TxBuilderFactory extends BaseTxBuilder {
   ): FreezeGuardTxBuilder {
     return new FreezeGuardTxBuilder(
       this.signerOrProvider,
+      this.publicClient,
       this.baseContracts,
       this.daoData as SubDAO,
       this.safeContract!,
@@ -133,6 +137,7 @@ export class TxBuilderFactory extends BaseTxBuilder {
   public async createAzoriusTxBuilder(): Promise<AzoriusTxBuilder> {
     const azoriusTxBuilder = new AzoriusTxBuilder(
       this.signerOrProvider,
+      this.publicClient,
       this.baseContracts,
       this.azoriusContracts!,
       this.daoData as AzoriusERC20DAO,

--- a/src/models/TxBuilderFactory.ts
+++ b/src/models/TxBuilderFactory.ts
@@ -30,6 +30,7 @@ export class TxBuilderFactory extends BaseTxBuilder {
   public fallbackHandler: string;
 
   private votesERC20WrapperMasterCopyAddress: string;
+  private votesERC20MasterCopyAddress: string;
 
   constructor(
     signerOrProvider: ethers.Signer | any,
@@ -38,6 +39,7 @@ export class TxBuilderFactory extends BaseTxBuilder {
     daoData: SafeMultisigDAO | AzoriusERC20DAO | AzoriusERC721DAO | SubDAO,
     fallbackHandler: string,
     votesERC20WrapperMasterCopyAddress: string,
+    votesERC20MasterCopyAddress: string,
     parentAddress?: string,
     parentTokenAddress?: string,
   ) {
@@ -53,6 +55,7 @@ export class TxBuilderFactory extends BaseTxBuilder {
     this.fallbackHandler = fallbackHandler;
     this.saltNum = getRandomBytes();
     this.votesERC20WrapperMasterCopyAddress = votesERC20WrapperMasterCopyAddress;
+    this.votesERC20MasterCopyAddress = votesERC20MasterCopyAddress;
   }
 
   public setSafeContract(safeAddress: string) {
@@ -135,6 +138,7 @@ export class TxBuilderFactory extends BaseTxBuilder {
       this.daoData as AzoriusERC20DAO,
       this.safeContract!,
       this.votesERC20WrapperMasterCopyAddress,
+      this.votesERC20MasterCopyAddress,
       this.parentAddress ? getAddress(this.parentAddress) : undefined,
       this.parentTokenAddress ? getAddress(this.parentTokenAddress) : undefined,
     );

--- a/src/providers/App/governance/reducer.ts
+++ b/src/providers/App/governance/reducer.ts
@@ -25,7 +25,6 @@ export const initialVotesTokenAccountData = {
   balance: null,
   delegatee: null,
   votingWeight: null,
-  isDelegatesSet: null,
 };
 
 export const governanceReducer = (state: FractalGovernance, action: FractalGovernanceActions) => {

--- a/src/providers/App/useReadOnlyValues.ts
+++ b/src/providers/App/useReadOnlyValues.ts
@@ -1,7 +1,6 @@
-import { ERC721__factory } from '@fractal-framework/fractal-contracts';
 import { useEffect, useState, useCallback } from 'react';
-import { getAddress } from 'viem';
-import useSignerOrProvider from '../../hooks/utils/useSignerOrProvider';
+import { erc721Abi, getAddress, getContract } from 'viem';
+import { usePublicClient } from 'wagmi';
 import {
   ReadOnlyState,
   Fractal,
@@ -25,7 +24,7 @@ const INITIAL_READ_ONLY_VALUES: ReadOnlyState = {
  */
 export const useReadOnlyValues = ({ node, governance }: Fractal, _account?: string) => {
   const [readOnlyValues, setReadOnlyValues] = useState<ReadOnlyState>(INITIAL_READ_ONLY_VALUES);
-  const signerOrProvider = useSignerOrProvider();
+  const publicClient = usePublicClient();
 
   const loadReadOnlyValues = useCallback(async () => {
     const getVotingWeight = async () => {
@@ -39,14 +38,18 @@ export const useReadOnlyValues = ({ node, governance }: Fractal, _account?: stri
           const tokenWeight = azoriusGovernance.votesToken?.votingWeight || 0n;
           return lockedTokenWeight || tokenWeight;
         case GovernanceType.AZORIUS_ERC721:
-          if (!_account || !azoriusGovernance.erc721Tokens || !signerOrProvider) {
+          if (!_account || !azoriusGovernance.erc721Tokens || !publicClient) {
             return 0n;
           }
           const userVotingWeight = (
             await Promise.all(
               azoriusGovernance.erc721Tokens.map(async ({ address, votingWeight }) => {
-                const tokenContract = ERC721__factory.connect(address, signerOrProvider);
-                const userBalance = (await tokenContract.balanceOf(_account)).toBigInt();
+                const tokenContract = getContract({
+                  abi: erc721Abi,
+                  address: address,
+                  client: publicClient,
+                });
+                const userBalance = await tokenContract.read.balanceOf([getAddress(_account)]);
                 return userBalance * votingWeight;
               }),
             )
@@ -70,7 +73,7 @@ export const useReadOnlyValues = ({ node, governance }: Fractal, _account?: stri
               governance.type === GovernanceType.AZORIUS_ERC721,
           },
     });
-  }, [node, governance, _account, signerOrProvider]);
+  }, [node, governance, _account, publicClient]);
   useEffect(() => {
     loadReadOnlyValues();
   }, [loadReadOnlyValues]);

--- a/src/providers/NetworkConfig/networks/base.ts
+++ b/src/providers/NetworkConfig/networks/base.ts
@@ -46,7 +46,7 @@ export const baseConfig: NetworkConfig = {
     fractalAzoriusMasterCopy: Azorius.address,
     fractalModuleMasterCopy: FractalModule.address,
     fractalRegistry: FractalRegistry.address,
-    votesERC20MasterCopy: VotesERC20.address,
+    votesERC20MasterCopy: getAddress(VotesERC20.address),
     linearVotingERC721MasterCopy: LinearVotingERC721.address,
     claimingMasterCopy: ERC20Claim.address,
     azoriusFreezeGuardMasterCopy: AzoriusFreezeGuard.address,

--- a/src/providers/NetworkConfig/networks/baseSepolia.ts
+++ b/src/providers/NetworkConfig/networks/baseSepolia.ts
@@ -46,7 +46,7 @@ export const baseSepoliaConfig: NetworkConfig = {
     fractalAzoriusMasterCopy: Azorius.address,
     fractalModuleMasterCopy: FractalModule.address,
     fractalRegistry: FractalRegistry.address,
-    votesERC20MasterCopy: VotesERC20.address,
+    votesERC20MasterCopy: getAddress(VotesERC20.address),
     linearVotingERC721MasterCopy: LinearVotingERC721.address,
     claimingMasterCopy: ERC20Claim.address,
     azoriusFreezeGuardMasterCopy: AzoriusFreezeGuard.address,

--- a/src/providers/NetworkConfig/networks/mainnet.ts
+++ b/src/providers/NetworkConfig/networks/mainnet.ts
@@ -46,7 +46,7 @@ export const mainnetConfig: NetworkConfig = {
     fractalAzoriusMasterCopy: Azorius.address,
     fractalModuleMasterCopy: FractalModule.address,
     fractalRegistry: FractalRegistry.address,
-    votesERC20MasterCopy: VotesERC20.address,
+    votesERC20MasterCopy: getAddress(VotesERC20.address),
     linearVotingERC721MasterCopy: '', // TODO - Add actual address once contract is deployed on mainnet
     claimingMasterCopy: ERC20Claim.address,
     azoriusFreezeGuardMasterCopy: AzoriusFreezeGuard.address,

--- a/src/providers/NetworkConfig/networks/optimism.ts
+++ b/src/providers/NetworkConfig/networks/optimism.ts
@@ -46,7 +46,7 @@ export const optimismConfig: NetworkConfig = {
     fractalAzoriusMasterCopy: Azorius.address,
     fractalModuleMasterCopy: FractalModule.address,
     fractalRegistry: FractalRegistry.address,
-    votesERC20MasterCopy: VotesERC20.address,
+    votesERC20MasterCopy: getAddress(VotesERC20.address),
     linearVotingERC721MasterCopy: LinearVotingERC721.address,
     claimingMasterCopy: ERC20Claim.address,
     azoriusFreezeGuardMasterCopy: AzoriusFreezeGuard.address,

--- a/src/providers/NetworkConfig/networks/polygon.ts
+++ b/src/providers/NetworkConfig/networks/polygon.ts
@@ -46,7 +46,7 @@ export const polygonConfig: NetworkConfig = {
     fractalAzoriusMasterCopy: Azorius.address,
     fractalModuleMasterCopy: FractalModule.address,
     fractalRegistry: FractalRegistry.address,
-    votesERC20MasterCopy: VotesERC20.address,
+    votesERC20MasterCopy: getAddress(VotesERC20.address),
     linearVotingERC721MasterCopy: '', // TODO - Add actual address once contract is deployed on polygon
     claimingMasterCopy: ERC20Claim.address,
     azoriusFreezeGuardMasterCopy: AzoriusFreezeGuard.address,

--- a/src/providers/NetworkConfig/networks/sepolia.ts
+++ b/src/providers/NetworkConfig/networks/sepolia.ts
@@ -46,7 +46,7 @@ export const sepoliaConfig: NetworkConfig = {
     fractalAzoriusMasterCopy: Azorius.address,
     fractalModuleMasterCopy: FractalModule.address,
     fractalRegistry: FractalRegistry.address,
-    votesERC20MasterCopy: VotesERC20.address,
+    votesERC20MasterCopy: getAddress(VotesERC20.address),
     linearVotingERC721MasterCopy: LinearVotingERC721.address,
     claimingMasterCopy: ERC20Claim.address,
     azoriusFreezeGuardMasterCopy: AzoriusFreezeGuard.address,

--- a/src/types/account.ts
+++ b/src/types/account.ts
@@ -5,7 +5,6 @@ export interface VotesData {
   balance: bigint | null;
   delegatee: string | null;
   votingWeight: bigint | null;
-  isDelegatesSet: boolean | null;
 }
 export type UnderlyingTokenData = Omit<
   ERC20TokenData,

--- a/src/types/contract.ts
+++ b/src/types/contract.ts
@@ -1,16 +1,11 @@
 import {
   GnosisSafeProxyFactory,
   ModuleProxyFactory,
-  Azorius,
-  LinearERC20Voting,
   FractalModule,
   FractalRegistry,
   MultisigFreezeGuard,
-  AzoriusFreezeGuard,
   MultisigFreezeVoting,
   ERC20FreezeVoting,
-  VotesERC20,
-  ERC20Claim,
   KeyValuePairs,
   ERC721FreezeVoting,
 } from '@fractal-framework/fractal-contracts';
@@ -25,24 +20,6 @@ export type ContractConnection<T> = {
   asSigner: T;
   asProvider: T;
 };
-
-export interface DAOContracts {
-  multiSendContract: ContractConnection<MultiSend>;
-  safeFactoryContract: ContractConnection<GnosisSafeProxyFactory>;
-  fractalAzoriusMasterCopyContract: ContractConnection<Azorius>;
-  linearVotingMasterCopyContract: ContractConnection<LinearERC20Voting>;
-  safeSingletonContract: ContractConnection<GnosisSafeL2>;
-  zodiacModuleProxyFactoryContract: ContractConnection<ModuleProxyFactory>;
-  fractalModuleMasterCopyContract: ContractConnection<FractalModule>;
-  fractalRegistryContract: ContractConnection<FractalRegistry>;
-  multisigFreezeGuardMasterCopyContract: ContractConnection<MultisigFreezeGuard>;
-  azoriusFreezeGuardMasterCopyContract: ContractConnection<AzoriusFreezeGuard>;
-  freezeMultisigVotingMasterCopyContract: ContractConnection<MultisigFreezeVoting>;
-  freezeERC20VotingMasterCopyContract: ContractConnection<ERC20FreezeVoting>;
-  votesTokenMasterCopyContract: ContractConnection<VotesERC20>;
-  claimingMasterCopyContract: ContractConnection<ERC20Claim>;
-  keyValuePairsContract: ContractConnection<KeyValuePairs>;
-}
 
 export interface BaseContracts {
   fractalModuleMasterCopyContract: FractalModule;

--- a/src/types/fractal.ts
+++ b/src/types/fractal.ts
@@ -182,7 +182,6 @@ export interface ITokenAccount {
   delegatee: string | undefined;
   votingWeight?: bigint;
   votingWeightString: string | undefined;
-  isDelegatesSet: boolean | undefined;
 }
 
 /**

--- a/src/types/fractal.ts
+++ b/src/types/fractal.ts
@@ -9,7 +9,6 @@ import {
   ERC20Claim,
   ERC20FreezeVoting,
   MultisigFreezeVoting,
-  VotesERC20,
   MultisigFreezeGuard,
   KeyValuePairs,
   ERC721FreezeVoting,
@@ -347,7 +346,6 @@ export interface FractalContracts {
   freezeMultisigVotingMasterCopyContract: ContractConnection<MultisigFreezeVoting>;
   freezeERC20VotingMasterCopyContract: ContractConnection<ERC20FreezeVoting>;
   freezeERC721VotingMasterCopyContract: ContractConnection<ERC721FreezeVoting>;
-  votesTokenMasterCopyContract: ContractConnection<VotesERC20>;
   claimingMasterCopyContract: ContractConnection<ERC20Claim>;
   keyValuePairsContract: ContractConnection<KeyValuePairs>;
 }

--- a/src/types/network.ts
+++ b/src/types/network.ts
@@ -31,7 +31,7 @@ export type NetworkConfig = {
     fractalAzoriusMasterCopy: string;
     fractalModuleMasterCopy: string;
     fractalRegistry: string;
-    votesERC20MasterCopy: string;
+    votesERC20MasterCopy: Address;
     linearVotingERC721MasterCopy: string;
     claimingMasterCopy: string;
     multisigFreezeGuardMasterCopy: string;

--- a/src/types/strategyAzorius.ts
+++ b/src/types/strategyAzorius.ts
@@ -2,7 +2,6 @@ import {
   Azorius,
   LinearERC20Voting,
   AzoriusFreezeGuard,
-  VotesERC20,
   ERC20Claim,
   LinearERC721Voting,
 } from '@fractal-framework/fractal-contracts';
@@ -12,6 +11,5 @@ export interface AzoriusContracts {
   linearVotingMasterCopyContract: LinearERC20Voting;
   linearVotingERC721MasterCopyContract: LinearERC721Voting;
   azoriusFreezeGuardMasterCopyContract: AzoriusFreezeGuard;
-  votesTokenMasterCopyContract: VotesERC20;
   claimingMasterCopyContract: ERC20Claim;
 }


### PR DESCRIPTION
Review and merge https://github.com/decentdao/fractal-interface/pull/1639 first, this PR builds on that one!

Main thing that this PR does is:

- Remove all imports of the `VotesERC20` TypeChain imports from `fractal-contracts` in the codebase.
- In favor using typed contract objects from viem using `getContract()`.

There was some other light cleanup, which I'll document in some inline PR review notes.