### PR TITLE
`Reskin` 1723 app crash no treasury assets

### DIFF
--- a/src/components/ui/modals/SendAssetsModal.tsx
+++ b/src/components/ui/modals/SendAssetsModal.tsx
@@ -145,7 +145,7 @@ export function SendAssetsModal({ close }: { close: () => void }) {
           textStyle="helper-text-base"
           as="span"
         >
-          {formatUSD(selectedAsset?.fiatBalance || 0)}
+          {formatUSD(selectedAsset.fiatBalance || 0)}
         </Text>
       </HStack>
       <Divider my="1.5rem" />

--- a/src/pages/daos/[daoAddress]/treasury/index.tsx
+++ b/src/pages/daos/[daoAddress]/treasury/index.tsx
@@ -12,10 +12,16 @@ import { useFractal } from '../../../../providers/App/AppProvider';
 export default function Treasury() {
   const {
     node: { daoName, daoAddress },
+    treasury: { assetsFungible },
   } = useFractal();
   const { t } = useTranslation('treasury');
   const { canUserCreateProposal } = useCanUserCreateProposal();
   const openSendAsset = useFractalModal(ModalType.SEND_ASSETS);
+
+  const hasAnyBalanceOfAnyFungibleTokens =
+    assetsFungible.reduce((p, c) => p + BigInt(c.balance), 0n) > 0n;
+
+  const showSendButton = canUserCreateProposal && hasAnyBalanceOfAnyFungibleTokens;
 
   return (
     <div>
@@ -32,8 +38,8 @@ export default function Treasury() {
             path: '',
           },
         ]}
-        buttonText={canUserCreateProposal ? t('buttonSendAssets') : undefined}
-        buttonClick={canUserCreateProposal ? openSendAsset : undefined}
+        buttonText={showSendButton ? t('buttonSendAssets') : undefined}
+        buttonClick={showSendButton ? openSendAsset : undefined}
         buttonTestId="link-send-assets"
       />
       <Flex


### PR DESCRIPTION
Fixes #1723 

Don't even show the Send Assets button when the Treasury has no fungible assets to send