### PR TITLE
Stop masking session recording text and inputs

### DIFF
--- a/src/helpers/errorLogging.ts
+++ b/src/helpers/errorLogging.ts
@@ -21,7 +21,10 @@ function initErrorLogging() {
         createRoutesFromChildren,
         matchRoutes,
       }),
-      Sentry.replayIntegration(),
+      Sentry.replayIntegration({
+        maskAllText: false,
+        maskAllInputs: false,
+      }),
       Sentry.feedbackIntegration({
         colorScheme: 'dark',
       }),


### PR DESCRIPTION
It's annoying not being able to see the toasts that are appearing in Sentry's session replays. I consider this change acceptable because _all of the data on these screens are public on the blockchain anyway_. We should be able to see the errors that our app is throwing.