### PR TITLE
`Reskin`- hover effect on parent link

### DIFF
--- a/src/components/pages/DaoDashboard/Info/DaoInfoHeader.tsx
+++ b/src/components/pages/DaoDashboard/Info/DaoInfoHeader.tsx
@@ -1,6 +1,5 @@
 import { Box, Flex, Text } from '@chakra-ui/react';
 import useDAOMetadata from '../../../../hooks/DAO/useDAOMetadata';
-import { useFractal } from '../../../../providers/App/AppProvider';
 import { DAOInfoCard } from '../../../ui/cards/DAOInfoCard';
 import { InfoBox } from '../../../ui/containers/InfoBox';
 import ExternalLink from '../../../ui/links/ExternalLink';
@@ -10,7 +9,6 @@ import { InfoTreasury } from './InfoTreasury';
 import { ParentLink } from './ParentLink';
 
 export function DaoInfoHeader() {
-  const { node, guardContracts, guard } = useFractal();
   const daoMetadata = useDAOMetadata();
 
   // using this gap method instead of 'gap' to make width percentages more precise, since they

--- a/src/components/pages/DaoDashboard/Info/InfoGovernance.tsx
+++ b/src/components/pages/DaoDashboard/Info/InfoGovernance.tsx
@@ -99,6 +99,7 @@ export function InfoGovernance() {
         alignItems="center"
         justifyContent="space-between"
         mb="0.25rem"
+        gap="0.5rem"
       >
         <Text color="neutral-7">{t('titleType')}</Text>
         <Text textAlign="right">
@@ -113,9 +114,10 @@ export function InfoGovernance() {
           alignItems="center"
           justifyContent="space-between"
           mb="0.25rem"
+          gap="0.5rem"
         >
           <Text color="neutral-7">{t('titleVotingPeriod')}</Text>
-          <Text>{governanceAzorius.votingStrategy?.votingPeriod?.formatted}</Text>
+          <Text textAlign="right">{governanceAzorius.votingStrategy?.votingPeriod?.formatted}</Text>
         </Flex>
       )}
       {governanceAzorius?.votingStrategy?.quorumPercentage && (
@@ -123,9 +125,12 @@ export function InfoGovernance() {
           alignItems="center"
           justifyContent="space-between"
           mb="0.25rem"
+          gap="0.5rem"
         >
           <Text color="neutral-7">{t('titleQuorum')}</Text>
-          <Text>{governanceAzorius.votingStrategy.quorumPercentage.formatted}</Text>
+          <Text textAlign="right">
+            {governanceAzorius.votingStrategy.quorumPercentage.formatted}
+          </Text>
         </Flex>
       )}
       {governanceAzorius?.votingStrategy?.quorumThreshold && (
@@ -133,9 +138,12 @@ export function InfoGovernance() {
           alignItems="center"
           justifyContent="space-between"
           mb="0.25rem"
+          gap="0.5rem"
         >
           <Text color="neutral-7">{t('titleQuorum')}</Text>
-          <Text>{governanceAzorius.votingStrategy.quorumThreshold.formatted}</Text>
+          <Text textAlign="right">
+            {governanceAzorius.votingStrategy.quorumThreshold.formatted}
+          </Text>
         </Flex>
       )}
       {timelockPeriod && (
@@ -143,9 +151,10 @@ export function InfoGovernance() {
           alignItems="center"
           justifyContent="space-between"
           mb="0.25rem"
+          gap="0.5rem"
         >
           <Text color="neutral-7">{t('timelock', { ns: 'common' })}</Text>
-          <Text>{timelockPeriod}</Text>
+          <Text textAlign="right">{timelockPeriod}</Text>
         </Flex>
       )}
       {executionPeriod && (
@@ -153,9 +162,10 @@ export function InfoGovernance() {
           alignItems="center"
           justifyContent="space-between"
           mb="0.25rem"
+          gap="0.5rem"
         >
           <Text color="neutral-7">{t('execution', { ns: 'common' })}</Text>
-          <Text>{executionPeriod}</Text>
+          <Text textAlign="right">{executionPeriod}</Text>
         </Flex>
       )}
     </Box>

--- a/src/components/pages/DaoDashboard/Info/ParentLink.tsx
+++ b/src/components/pages/DaoDashboard/Info/ParentLink.tsx
@@ -29,6 +29,7 @@ export function ParentLink() {
       onClick={action.resetDAO}
       marginBottom="1rem"
       as={RouterLink}
+      width="fit-content"
     >
       <HStack>
         <Icon


### PR DESCRIPTION
This PR contains following changes:

- Adjust `ParentLink` width to `fit-content` so that it's hover effect doesn't take whole row
- Slightly improve `InfoGovernance` - for long values `justify-content` wasn't working as expected and text was aligned to the left side - fix this

Closes #1714 