### PR TITLE
`Reskin` 1730 add blur sidebar

### DIFF
--- a/src/components/ui/page/Layout/index.tsx
+++ b/src/components/ui/page/Layout/index.tsx
@@ -34,8 +34,8 @@ export default function Layout() {
         ref={headerContainerRef}
       >
         <Box
-          bg="#26212AD6"
-          backdropFilter="blur(12px)"
+          bg="neutral-2"
+          boxShadow="0px 1px 0px 0px #161219"
           position="fixed"
           w="full"
           maxW="100vw"

--- a/src/components/ui/page/Navigation/NavigationLinks.tsx
+++ b/src/components/ui/page/Navigation/NavigationLinks.tsx
@@ -86,12 +86,14 @@ function InternalLinks({
         _hover={{ maxWidth: '100%' }}
         transitionDuration="0.2s"
         overflow={{ md: 'hidden' }}
-        bg={{ md: 'neutral-2' }}
         mt={{ md: 12 }}
         mb={{ md: 3 }}
+        bg={{ md: '#26212AD6' }}
         borderColor={{ md: 'neutral-3' }}
         borderRadius={{ md: 8 }}
         borderWidth={{ md: 1 }}
+        backdropFilter="blur(12px)"
+        boxShadow="0px 1px 0px 0px #161219"
       >
         <NavigationLink
           href={DAO_ROUTES.dao.relative(addressPrefix, address)}


### PR DESCRIPTION
Add blur to Sidebar. 

Also per a quick conversation with @nicolaus-sherrill, I've updated the Header as well:
- Removed the backdropFilter (blur) from Parent Header
- added `box-shadow` 
- added `neutral-2` bg for Header

These changes allow for the menus to properly have the blur effect applied.

Closes #1730