### PR TITLE
`Reskin` Moves ProposalCountdown from the Badge component

### DIFF
--- a/src/components/Proposals/ProposalCard/ProposalCard.tsx
+++ b/src/components/Proposals/ProposalCard/ProposalCard.tsx
@@ -16,6 +16,7 @@ import { ActivityDescription } from '../../Activity/ActivityDescription';
 import { Badge } from '../../ui/badges/Badge';
 import QuorumBadge from '../../ui/badges/QuorumBadge';
 import { SnapshotIcon } from '../../ui/badges/Snapshot';
+import { ProposalCountdown } from '../../ui/proposal/ProposalCountdown';
 
 function ProposalCard({ proposal }: { proposal: FractalProposal }) {
   const {
@@ -66,7 +67,12 @@ function ProposalCard({ proposal }: { proposal: FractalProposal }) {
             <Badge
               labelKey={proposal.state!}
               size="sm"
+            />
+            <ProposalCountdown
               proposal={proposal}
+              showIcon={false}
+              textColor="neutral-7"
+              textStyle="label-base"
             />
             {isSnapshotProposal && (
               <Box ml={1}>

--- a/src/components/Proposals/ProposalCard/ProposalCard.tsx
+++ b/src/components/Proposals/ProposalCard/ProposalCard.tsx
@@ -72,7 +72,6 @@ function ProposalCard({ proposal }: { proposal: FractalProposal }) {
               proposal={proposal}
               showIcon={false}
               textColor="neutral-7"
-              textStyle="label-base"
             />
             {isSnapshotProposal && (
               <Box ml={1}>

--- a/src/components/Proposals/ProposalInfo.tsx
+++ b/src/components/Proposals/ProposalInfo.tsx
@@ -50,7 +50,6 @@ export function ProposalInfo({
           proposal={proposal}
           showIcon={false}
           textColor="neutral-7"
-          textStyle="label-base"
         />
         {isSnapshotProposal && (
           <>

--- a/src/components/Proposals/ProposalInfo.tsx
+++ b/src/components/Proposals/ProposalInfo.tsx
@@ -37,7 +37,7 @@ export function ProposalInfo({
       padding="1.5rem"
     >
       <Flex
-        gap={4}
+        gap={2}
         alignItems="center"
       >
         {proposal.state && (

--- a/src/components/Proposals/ProposalInfo.tsx
+++ b/src/components/Proposals/ProposalInfo.tsx
@@ -11,6 +11,7 @@ import { Badge } from '../ui/badges/Badge';
 import { SnapshotButton } from '../ui/badges/Snapshot';
 import { ModalType } from '../ui/modals/ModalProvider';
 import { useFractalModal } from '../ui/modals/useFractalModal';
+import { ProposalCountdown } from '../ui/proposal/ProposalCountdown';
 import ProposalExecutableCode from '../ui/proposal/ProposalExecutableCode';
 import CeleryButtonWithIcon from '../ui/utils/CeleryButtonWithIcon';
 
@@ -43,9 +44,14 @@ export function ProposalInfo({
           <Badge
             size="base"
             labelKey={proposal.state}
-            proposal={proposal}
           />
         )}
+        <ProposalCountdown
+          proposal={proposal}
+          showIcon={false}
+          textColor="neutral-7"
+          textStyle="label-base"
+        />
         {isSnapshotProposal && (
           <>
             <SnapshotButton snapshotENS={`${daoSnapshotENS}/proposal/${proposal.proposalId}`} />

--- a/src/components/ui/badges/Badge.tsx
+++ b/src/components/ui/badges/Badge.tsx
@@ -2,8 +2,7 @@ import { Box, Flex, Text, Tooltip } from '@chakra-ui/react';
 import { ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 import { TOOLTIP_MAXW } from '../../../constants/common';
-import { FractalProposalState, DAOState, FractalProposal } from '../../../types';
-import { ProposalCountdown } from '../proposal/ProposalCountdown';
+import { FractalProposalState, DAOState } from '../../../types';
 
 type BadgeType = {
   tooltipKey?: string;
@@ -109,10 +108,9 @@ interface IBadge {
   size: Size;
   labelKey: keyof typeof BADGE_MAPPING;
   children?: ReactNode;
-  proposal?: FractalProposal;
 }
 
-export function Badge({ labelKey, children, size, proposal }: IBadge) {
+export function Badge({ labelKey, children, size }: IBadge) {
   const { tooltipKey, ...colors } = BADGE_MAPPING[labelKey];
   const sizes = BADGE_SIZES[size];
 
@@ -147,14 +145,6 @@ export function Badge({ labelKey, children, size, proposal }: IBadge) {
         >
           {children || t(labelKey)}
         </Text>
-        {proposal && (
-          <ProposalCountdown
-            proposal={proposal}
-            showIcon={false}
-            textColor={colors.textColor}
-            textStyle="label-base"
-          />
-        )}
       </Flex>
     </Tooltip>
   );

--- a/src/components/ui/proposal/ProposalCountdown.tsx
+++ b/src/components/ui/proposal/ProposalCountdown.tsx
@@ -89,7 +89,7 @@ export function ProposalCountdown({
         >
           <Text
             color={textColor}
-            textStyle='label-base'
+            textStyle="label-base"
           >
             {showDays && `${zeroPad(daysLeft)}:`}
             {showHours && `${zeroPad(hoursLeft)}:`}

--- a/src/components/ui/proposal/ProposalCountdown.tsx
+++ b/src/components/ui/proposal/ProposalCountdown.tsx
@@ -22,13 +22,11 @@ export function ProposalCountdown({
   proposal,
   showIcon = true,
   textColor = 'white-0',
-  textStyle = 'label-base', // previous default
 }: {
   proposal: FractalProposal;
   showIcon?: boolean;
   // custom text color and style
   textColor?: string;
-  textStyle?: string;
 }) {
   const totalSecondsLeft = useProposalCountdown(proposal);
   const { t } = useTranslation('proposal');
@@ -91,7 +89,7 @@ export function ProposalCountdown({
         >
           <Text
             color={textColor}
-            textStyle={textStyle}
+            textStyle='label-base'
           >
             {showDays && `${zeroPad(daysLeft)}:`}
             {showHours && `${zeroPad(hoursLeft)}:`}


### PR DESCRIPTION
Separate the `ProposalCountdown`  from the `Badge` component

![image](https://github.com/decentdao/fractal-interface/assets/38386583/521f1395-639e-4b54-b3ee-61543ecb449b)
![image](https://github.com/decentdao/fractal-interface/assets/38386583/2ac4a867-e2a1-4917-9c59-ca9a5dfc94ad)
![image](https://github.com/decentdao/fractal-interface/assets/38386583/0ede6244-f8ce-4a17-a1df-5bc27ad3643f)

Fixes #1695 