### PR TITLE
Swap out `getUsdBalances` with `getBalances`

### DIFF
--- a/src/components/pages/DAOTreasury/hooks/useFormatCoins.tsx
+++ b/src/components/pages/DAOTreasury/hooks/useFormatCoins.tsx
@@ -1,4 +1,4 @@
-import { SafeBalanceUsdResponse } from '@safe-global/safe-service-client';
+import { SafeBalanceResponse } from '@safe-global/safe-service-client';
 import { useEffect, useState } from 'react';
 import { maxUint256, zeroAddress } from 'viem';
 import { logError } from '../../../../helpers/errorLogging';
@@ -18,7 +18,7 @@ export interface TokenDisplayData {
   rawValue: string;
 }
 
-export function useFormatCoins(assets: SafeBalanceUsdResponse[]) {
+export function useFormatCoins(assets: SafeBalanceResponse[]) {
   const { chain, nativeTokenIcon } = useNetworkConfig();
   const [totalFiatValue, setTotalFiatValue] = useState(0);
   const [displayData, setDisplayData] = useState<TokenDisplayData[]>([]);

--- a/src/components/pages/DAOTreasury/hooks/useSendAssets.ts
+++ b/src/components/pages/DAOTreasury/hooks/useSendAssets.ts
@@ -1,4 +1,4 @@
-import { SafeBalanceUsdResponse } from '@safe-global/safe-service-client';
+import { SafeBalanceResponse } from '@safe-global/safe-service-client';
 import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { encodeAbiParameters, parseAbiParameters, isAddress, getAddress, Hex } from 'viem';
@@ -13,7 +13,7 @@ const useSendAssets = ({
   nonce,
 }: {
   transferAmount: bigint;
-  asset: SafeBalanceUsdResponse;
+  asset: SafeBalanceResponse;
   destinationAddress: string | undefined;
   nonce: number | undefined;
 }) => {

--- a/src/components/ui/modals/SendAssetsModal.tsx
+++ b/src/components/ui/modals/SendAssetsModal.tsx
@@ -5,10 +5,7 @@ import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useFractal } from '../../../providers/App/AppProvider';
 import { BigIntValuePair } from '../../../types';
-import {
-  formatCoinFromAsset,
-  formatCoinUnitsFromAsset,
-} from '../../../utils/numberFormats';
+import { formatCoinFromAsset, formatCoinUnitsFromAsset } from '../../../utils/numberFormats';
 import useSendAssets from '../../pages/DAOTreasury/hooks/useSendAssets';
 import { BigIntInput } from '../forms/BigIntInput';
 import { CustomNonceInput } from '../forms/CustomNonceInput';

--- a/src/components/ui/modals/SendAssetsModal.tsx
+++ b/src/components/ui/modals/SendAssetsModal.tsx
@@ -1,6 +1,6 @@
 import { Box, Divider, Flex, Select, HStack, Text, Button } from '@chakra-ui/react';
 import { LabelWrapper } from '@decent-org/fractal-ui';
-import { SafeBalanceUsdResponse } from '@safe-global/safe-service-client';
+import { SafeBalanceResponse } from '@safe-global/safe-service-client';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useFractal } from '../../../providers/App/AppProvider';
@@ -8,7 +8,6 @@ import { BigIntValuePair } from '../../../types';
 import {
   formatCoinFromAsset,
   formatCoinUnitsFromAsset,
-  formatUSD,
 } from '../../../utils/numberFormats';
 import useSendAssets from '../../pages/DAOTreasury/hooks/useSendAssets';
 import { BigIntInput } from '../forms/BigIntInput';
@@ -25,19 +24,13 @@ export function SendAssetsModal({ close }: { close: () => void }) {
 
   const fungibleAssetsWithBalance = assetsFungible.filter(asset => parseFloat(asset.balance) > 0);
 
-  const [selectedAsset, setSelectedAsset] = useState<SafeBalanceUsdResponse>(
+  const [selectedAsset, setSelectedAsset] = useState<SafeBalanceResponse>(
     fungibleAssetsWithBalance[0],
   );
   const [inputAmount, setInputAmount] = useState<BigIntValuePair>();
   const [nonceInput, setNonceInput] = useState<number | undefined>(safe!.nonce);
 
   const [destination, setDestination] = useState<string>();
-
-  const hasFiatBalance = Number(selectedAsset.fiatBalance) > 0;
-
-  const convertedTotal = formatUSD(
-    Number(inputAmount?.value || '0') * Number(selectedAsset.fiatConversion),
-  );
 
   const sendAssets = useSendAssets({
     transferAmount: inputAmount?.bigintValue || 0n,
@@ -126,14 +119,7 @@ export function SendAssetsModal({ close }: { close: () => void }) {
             balance: formatCoinFromAsset(selectedAsset, false),
           })}
         </Text>
-        {hasFiatBalance && <Text>{convertedTotal}</Text>}
       </HStack>
-      <Text
-        textStyle="text-sm-sans-regular"
-        color="grayscale.500"
-      >
-        {formatUSD(selectedAsset.fiatBalance)}
-      </Text>
       <Divider
         color="chocolate.700"
         marginTop="0.75rem"

--- a/src/components/ui/modals/Stake.tsx
+++ b/src/components/ui/modals/Stake.tsx
@@ -1,5 +1,5 @@
 import { Box, Button, Flex, Text } from '@chakra-ui/react';
-import { SafeBalanceUsdResponse } from '@safe-global/safe-service-client';
+import { SafeBalanceResponse } from '@safe-global/safe-service-client';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
@@ -21,7 +21,7 @@ export default function StakeModal({ close }: { close: () => void }) {
 
   const fungibleAssetsWithBalance = assetsFungible.filter(asset => parseFloat(asset.balance) > 0);
 
-  const [selectedAsset] = useState<SafeBalanceUsdResponse>(fungibleAssetsWithBalance[0]);
+  const [selectedAsset] = useState<SafeBalanceResponse>(fungibleAssetsWithBalance[0]);
   const [inputAmount, setInputAmount] = useState<BigIntValuePair>();
   const onChangeAmount = (value: BigIntValuePair) => {
     setInputAmount(value);

--- a/src/hooks/DAO/loaders/useFractalTreasury.ts
+++ b/src/hooks/DAO/loaders/useFractalTreasury.ts
@@ -28,7 +28,7 @@ export const useFractalTreasury = () => {
       return;
     }
     const [assetsFungible, assetsNonFungible, transfers] = await Promise.all([
-      safeAPI.getUsdBalances(daoAddress).catch(e => {
+      safeAPI.getBalances(daoAddress).catch(e => {
         logError(e);
         return [];
       }),

--- a/src/providers/App/hooks/usePriceAPI.ts
+++ b/src/providers/App/hooks/usePriceAPI.ts
@@ -1,4 +1,4 @@
-import { SafeBalanceUsdResponse } from '@safe-global/safe-service-client';
+import { SafeBalanceResponse } from '@safe-global/safe-service-client';
 import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'react-toastify';
@@ -10,7 +10,7 @@ export default function usePriceAPI() {
   const { t } = useTranslation('treasury');
 
   const getTokenPrices = useCallback(
-    async (tokens: SafeBalanceUsdResponse[]) => {
+    async (tokens: SafeBalanceResponse[]) => {
       if (chain.id !== 1) {
         // Support only mainnet for now. CoinGecko does not support Sepolia (obviously, I guess :D) and we don't want to burn API credits to "simulate" prices display
         return;

--- a/src/providers/App/hooks/useSafeAPI.ts
+++ b/src/providers/App/hooks/useSafeAPI.ts
@@ -7,8 +7,6 @@ import SafeServiceClient, {
   OwnerResponse,
   SafeBalanceResponse,
   SafeBalancesOptions,
-  SafeBalancesUsdOptions,
-  SafeBalanceUsdResponse,
   SafeCollectibleResponse,
   SafeCollectiblesOptions,
   SafeCreationInfoResponse,
@@ -164,19 +162,6 @@ class CachingSafeServiceClient extends SafeServiceClient {
     const value = await this.request('getBalances' + safeAddress + options?.toString(), 1, () => {
       return super.getBalances(safeAddress, options);
     });
-    return value;
-  }
-  override async getUsdBalances(
-    safeAddress: string,
-    options?: SafeBalancesUsdOptions | undefined,
-  ): Promise<SafeBalanceUsdResponse[]> {
-    const value = await this.request(
-      'getUsdBalances' + safeAddress + options?.toString(),
-      1,
-      () => {
-        return super.getUsdBalances(safeAddress, options);
-      },
-    );
     return value;
   }
   override async getCollectibles(

--- a/src/types/createDAO.ts
+++ b/src/types/createDAO.ts
@@ -1,4 +1,4 @@
-import { SafeBalanceUsdResponse, SafeCollectibleResponse } from '@safe-global/safe-service-client';
+import { SafeBalanceResponse, SafeCollectibleResponse } from '@safe-global/safe-service-client';
 import { FormikProps } from 'formik';
 import { Address } from 'viem';
 import { DAOCreateMode } from '../components/DaoCreator/formComponents/EstablishEssentials';
@@ -119,7 +119,7 @@ export type AddressValidation = {
 };
 
 export type TokenToFund = {
-  asset: SafeBalanceUsdResponse;
+  asset: SafeBalanceResponse;
   amount: BigIntValuePair;
 };
 

--- a/src/types/daoTreasury.ts
+++ b/src/types/daoTreasury.ts
@@ -1,5 +1,5 @@
 import {
-  SafeBalanceUsdResponse,
+  SafeBalanceResponse,
   SafeCollectibleResponse,
   TransferResponse,
 } from '@safe-global/safe-service-client';
@@ -45,7 +45,7 @@ export type Transaction =
 
 export interface ITreasury {
   transactions: Transaction[];
-  assetsFungible: SafeBalanceUsdResponse[];
+  assetsFungible: SafeBalanceResponse[];
   assetsNonFungible: SafeCollectibleResponse[];
   transfers?: AllTransfersListResponse;
   treasuryIsLoading: boolean;

--- a/src/types/fractal.ts
+++ b/src/types/fractal.ts
@@ -20,7 +20,7 @@ import {
   SafeMultisigTransactionWithTransfersResponse,
   SafeModuleTransactionWithTransfersResponse,
   EthereumTxWithTransfersResponse,
-  SafeBalanceUsdResponse,
+  SafeBalanceResponse,
   SafeCollectibleResponse,
 } from '@safe-global/safe-service-client';
 import { Dispatch } from 'react';
@@ -277,7 +277,7 @@ export interface FreezeGuard {
 }
 
 export interface FractalTreasury {
-  assetsFungible: SafeBalanceUsdResponse[];
+  assetsFungible: SafeBalanceResponse[];
   assetsNonFungible: SafeCollectibleResponse[];
   transfers?: AllTransfersListResponse;
 }

--- a/src/utils/numberFormats.ts
+++ b/src/utils/numberFormats.ts
@@ -1,4 +1,4 @@
-import { SafeBalanceUsdResponse } from '@safe-global/safe-service-client';
+import { SafeBalanceResponse } from '@safe-global/safe-service-client';
 import BigDecimal from 'js-big-decimal';
 import { formatEther, formatUnits } from 'viem';
 
@@ -40,7 +40,7 @@ const formatCoinUnits = (
     : parseFloat(formatEther(BigInt(rawBalance)));
 };
 
-export const formatCoinUnitsFromAsset = (asset: SafeBalanceUsdResponse): number => {
+export const formatCoinUnitsFromAsset = (asset: SafeBalanceResponse): number => {
   return formatCoinUnits(asset.balance, asset.token?.decimals, asset.token?.symbol);
 };
 
@@ -66,7 +66,7 @@ export const formatCoin = (
   return coinFormatter.format(amount);
 };
 
-export const formatCoinFromAsset = (asset: SafeBalanceUsdResponse, truncate: boolean): string => {
+export const formatCoinFromAsset = (asset: SafeBalanceResponse, truncate: boolean): string => {
   return formatCoin(asset.balance, truncate, asset?.token?.decimals, asset?.token?.symbol);
 };
 


### PR DESCRIPTION
Safe API just stopped supporting `getUsdBalances` 
However, they weren't returning fiat values there for a long time
So we just swapping out `getUsdBalances` to `getBalances`
Now showing coins works like a charm