### PR TITLE
`Reskin` | Quorum progress bug

### DIFF
--- a/src/components/Proposals/ProposalSummary.tsx
+++ b/src/components/Proposals/ProposalSummary.tsx
@@ -94,15 +94,18 @@ export default function ProposalSummary({ proposal }: { proposal: AzoriusProposa
       : isERC721
         ? votingStrategy.quorumThreshold!.value
         : 1n;
+
   const reachedQuorum = isERC721
     ? totalVotesCasted - no
     : votesToken
       ? (totalVotesCasted - no) / votesTokenDecimalsDenominator
       : 0n;
+
   const totalQuorum = isERC721
-    ? strategyQuorum
+    ? Number(strategyQuorum)
     : votesToken
-      ? (votesToken.totalSupply / votesTokenDecimalsDenominator / 100n) * strategyQuorum
+      ? (Number(votesToken.totalSupply / votesTokenDecimalsDenominator) * Number(strategyQuorum)) /
+        100
       : undefined;
 
   const ShowVotingPowerButton = (

--- a/src/components/Proposals/ProposalSummary.tsx
+++ b/src/components/Proposals/ProposalSummary.tsx
@@ -245,7 +245,7 @@ export default function ProposalSummary({ proposal }: { proposal: AzoriusProposa
                   : undefined,
             },
           )}
-          reachedQuorum={reachedQuorum}
+          reachedQuorum={Number(reachedQuorum)}
           totalQuorum={totalQuorum}
           unit={isERC20 ? '%' : ''}
         />

--- a/src/components/Proposals/SnapshotProposalDetails/SnapshotProposalSummary.tsx
+++ b/src/components/Proposals/SnapshotProposalDetails/SnapshotProposalSummary.tsx
@@ -136,7 +136,7 @@ export default function SnapshotProposalSummary({ proposal }: ISnapshotProposalS
           <Box marginTop={4}>
             <QuorumProgressBar
               reachedQuorum={BigInt(totalVotesCasted)}
-              totalQuorum={proposal.quorum ? BigInt(proposal.quorum) : undefined}
+              totalQuorum={proposal.quorum}
               unit=""
             />
           </Box>

--- a/src/components/Proposals/SnapshotProposalDetails/SnapshotProposalSummary.tsx
+++ b/src/components/Proposals/SnapshotProposalDetails/SnapshotProposalSummary.tsx
@@ -135,7 +135,7 @@ export default function SnapshotProposalSummary({ proposal }: ISnapshotProposalS
         {!!proposal.quorum && (
           <Box marginTop={4}>
             <QuorumProgressBar
-              reachedQuorum={BigInt(totalVotesCasted)}
+              reachedQuorum={totalVotesCasted}
               totalQuorum={proposal.quorum}
               unit=""
             />

--- a/src/components/ui/utils/ProgressBar.tsx
+++ b/src/components/ui/utils/ProgressBar.tsx
@@ -67,7 +67,7 @@ interface QuorumProgressBarProps {
   helperText?: string;
   unit?: string;
   reachedQuorum: bigint;
-  totalQuorum?: bigint;
+  totalQuorum?: number;
 }
 
 export function QuorumProgressBar({
@@ -84,7 +84,7 @@ export function QuorumProgressBar({
     >
       <ProgressBar
         value={Number(reachedQuorum)}
-        max={totalQuorum ? Number(totalQuorum) : undefined}
+        max={totalQuorum}
         unit={unit}
         label={t('quorum', { ns: 'common' })}
         bg="neutral-4"
@@ -99,7 +99,7 @@ export function QuorumProgressBar({
                   as={Check}
                 />
               )}
-              {reachedQuorum.toString()} / {totalQuorum.toString()}
+              {reachedQuorum.toString()} / {totalQuorum}
             </Text>
           ) : undefined
         }

--- a/src/components/ui/utils/ProgressBar.tsx
+++ b/src/components/ui/utils/ProgressBar.tsx
@@ -66,7 +66,7 @@ export default function ProgressBar({
 interface QuorumProgressBarProps {
   helperText?: string;
   unit?: string;
-  reachedQuorum: bigint;
+  reachedQuorum: number;
   totalQuorum?: number;
 }
 
@@ -83,7 +83,7 @@ export function QuorumProgressBar({
       marginTop={2}
     >
       <ProgressBar
-        value={Number(reachedQuorum)}
+        value={reachedQuorum}
         max={totalQuorum}
         unit={unit}
         label={t('quorum', { ns: 'common' })}
@@ -99,7 +99,7 @@ export function QuorumProgressBar({
                   as={Check}
                 />
               )}
-              {reachedQuorum.toString()} / {totalQuorum}
+              {reachedQuorum} / {totalQuorum}
             </Text>
           ) : undefined
         }


### PR DESCRIPTION
Addresses #1793 

Turns out it wasn't really a reskin, but a till-now undiscovered bug.

It's a pretty wild edge case that appears because of two conditions:

- `bigint`s cannot have less-than-one values
- the required voting quorum is a percentage that leads to a token count less than 1. In the report's case, it was `4% of 14 == 0.56`

The `QuorumProgressBar` worked with `bigints`, and the `totalQuorum` calc resulted in 0 in this edge case, causing it to become false-y and leading to the bug. I have updated the calculation to use numbers instead.

...

As I write this I suddenly realise updating `QuorumProgressBar`'s `reachedQuorum` and `totalQuorum` to `numbers` might introduce another bug for potentially large values of `totalQuorum` that overflow the max `number` value. 

Is that likely to happen, seeing as `totalQuorum` will always be a percentage of `votesToken.totalSupply`? Thoughts?