### PR TITLE
Update useSendAssets to use encodeFunctionData for ERC20 transfer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fractal-interface",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fractal-interface",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "hasInstallScript": true,
       "dependencies": {
         "@adraffy/ens-normalize": "^1.10.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fractal-interface",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "private": true,
   "dependencies": {
     "@adraffy/ens-normalize": "^1.10.1",

--- a/src/components/pages/DAOTreasury/hooks/useSendAssets.ts
+++ b/src/components/pages/DAOTreasury/hooks/useSendAssets.ts
@@ -1,13 +1,7 @@
 import { SafeBalanceResponse } from '@safe-global/safe-service-client';
 import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
-import {
-  isAddress,
-  getAddress,
-  Hex,
-  encodeFunctionData,
-  erc20Abi,
-} from 'viem';
+import { isAddress, getAddress, Hex, encodeFunctionData, erc20Abi } from 'viem';
 import useSubmitProposal from '../../../../hooks/DAO/proposal/useSubmitProposal';
 import { ProposalExecuteData } from '../../../../types';
 import { formatCoin } from '../../../../utils/numberFormats';

--- a/src/components/pages/DAOTreasury/hooks/useSendAssets.ts
+++ b/src/components/pages/DAOTreasury/hooks/useSendAssets.ts
@@ -1,7 +1,13 @@
 import { SafeBalanceResponse } from '@safe-global/safe-service-client';
 import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
-import { encodeAbiParameters, parseAbiParameters, isAddress, getAddress, Hex } from 'viem';
+import {
+  isAddress,
+  getAddress,
+  Hex,
+  encodeFunctionData,
+  erc20Abi,
+} from 'viem';
 import useSubmitProposal from '../../../../hooks/DAO/proposal/useSubmitProposal';
 import { ProposalExecuteData } from '../../../../types';
 import { formatCoin } from '../../../../utils/numberFormats';
@@ -35,10 +41,11 @@ const useSendAssets = ({
       isEth && destinationAddress ? getAddress(destinationAddress) : getAddress(asset.tokenAddress);
     if (!isEth && destinationAddress && isAddress(destinationAddress)) {
       calldatas = [
-        encodeAbiParameters(parseAbiParameters('address, uint256'), [
-          destinationAddress,
-          transferAmount,
-        ]),
+        encodeFunctionData({
+          abi: erc20Abi,
+          functionName: 'transfer',
+          args: [destinationAddress, transferAmount],
+        }),
       ];
     }
 


### PR DESCRIPTION
Fixes #1818 

Hot fix. Updates replaces  `encodeAbiParameters` with `EncodeFunctionData`