### PR TITLE
Add proxy so plausible analytics won't be blocked

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -1,1 +1,3 @@
 /* /index.html 200
+/third-party/js/script.js https://plausible.io/js/script.js 200
+/third-party/api/event https://plausible.io/api/event 200

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,3 +1,1 @@
 /* /index.html 200
-/third-party/js/script.js https://plausible.io/js/script.outbound-links.js 200
-/third-party/api/event https://plausible.io/api/event 200

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,3 +1,3 @@
 /* /index.html 200
-/third-party/js/script.js https://plausible.io/js/script.js 200
+/third-party/js/script.js https://plausible.io/js/script.outbound-links.js 200
 /third-party/api/event https://plausible.io/api/event 200


### PR DESCRIPTION
Closes #1845 

The Plausible script is added via Netlify post processing: https://app.netlify.com/sites/fractal-dev/configuration/deploys#post-processing

The code in this PR exists to create a proxy for loading the Plausible script, to get around ad blockers. See the following links for an explanation:
https://plausible.io/docs/proxy/introduction#options-for-dealing-with-missing-data-as-a-site-owner
https://plausible.io/docs/proxy/guides/netlify